### PR TITLE
feat: Add Streamable HTTP transport and Authorization header forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
 -   **Customizable Schemas:** Manually register schemas for specific routes using `RegisterSchema` for fine-grained control.
 -   **Selective Exposure:** Filter which endpoints are exposed using operation IDs or tags.
 -   **Flexible Deployment:** Mount the MCP server within the same Gin app or deploy it separately.
+-   **Streamable HTTP Transport:** Opt in to MCP spec 2025-03-26 for stateless, load-balancer-friendly deployments with no session affinity required.
+-   **Authorization Header Forwarding:** Automatically forward the client's `Authorization` header to every internal tool-execution call, enabling MCP access to JWT-protected APIs.
 
 ## Installation
 
@@ -346,12 +348,67 @@ mcp.SetExecuteToolFunc(func(operationID string, parameters map[string]interface{
 
 This eliminates the need for static BaseURL configuration at startup, perfect for multi-tenant proxy environments!
 
+### Streamable HTTP Transport (horizontal scaling)
+
+By default, Gin-MCP uses the **SSE transport** (MCP spec 2024-11-05), which requires a persistent GET connection to be routed to the **same pod** as subsequent POST requests. This forces load balancers to use session affinity (sticky sessions), which is incompatible with horizontal autoscaling and unsupported by many managed load balancers (e.g. GCP, AWS ALB).
+
+The **Streamable HTTP transport** (MCP spec 2025-03-26) solves this: every POST returns the JSON-RPC response directly in the HTTP body. No prior GET connection or pod affinity is required.
+
+```go
+mcp := server.New(r, &server.Config{
+    Name:          "My API",
+    BaseURL:       "https://api.example.com",
+    TransportType: server.TransportTypeStreamableHTTP,
+})
+mcp.Mount("/mcp")
+```
+
+MCP clients connect with a single `POST /mcp` — no prior GET needed.
+
+#### Origin validation (DNS rebinding protection)
+
+Per [MCP spec 2025-03-26 §Security](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#security-considerations), servers should validate the `Origin` header. Use `AllowedOrigins` to restrict browser-originated requests:
+
+```go
+mcp := server.New(r, &server.Config{
+    Name:          "My API",
+    BaseURL:       "https://api.example.com",
+    TransportType: server.TransportTypeStreamableHTTP,
+    // Only allow requests from this browser origin.
+    // Omit (or leave nil) when authentication already prevents unauthorised access.
+    AllowedOrigins: []string{"https://app.example.com"},
+})
+```
+
+- Requests **with** an `Origin` header not in the list → `403 Forbidden`.
+- Requests **without** an `Origin` header (server-to-server: `curl`, Node.js, etc.) → always allowed.
+- Empty / nil `AllowedOrigins` → all origins permitted (suitable when a Bearer token is required).
+
+### Authorization Header Forwarding
+
+When your Gin endpoints are protected by JWT Bearer tokens, you can forward the client's `Authorization` header to every internal tool-execution HTTP call:
+
+```go
+mcp := server.New(r, &server.Config{
+    Name:               "My API",
+    BaseURL:            "https://api.example.com",
+    ForwardAuthHeaders: true,
+})
+mcp.Mount("/mcp")
+```
+
+- **SSE transport**: the header is captured once at SSE connection time and reused for all subsequent tool calls on that connection.
+- **Streamable HTTP transport**: the header is captured per POST request (each call is independent).
+- Default: `false` (disabled, for backward compatibility).
+
 ## Connecting MCP Clients
 
 Once your Gin application with Gin-MCP is running:
 
 1.  Start your application.
-2.  In your MCP client, provide the URL where you mounted the MCP server (e.g., `http://localhost:8080/mcp`) as the SSE endpoint:
+2.  In your MCP client, provide the URL where you mounted the MCP server (e.g., `http://localhost:8080/mcp`):
+    - **SSE transport (default)**: connect as an SSE endpoint (GET then POST to the same path).
+    - **Streamable HTTP transport**: connect as a plain HTTP endpoint (POST only).
     - **Cursor**: Settings → MCP → Add Server
     - **Claude Desktop**: Add to MCP configuration file
     - **Continue**: Configure in VS Code settings

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -25,11 +25,17 @@ const (
 	writeTimeout      = 10 * time.Second
 )
 
+// ConnectionContext holds the context for an SSE connection
+type ConnectionContext struct {
+	Channel    chan *types.MCPMessage
+	AuthHeader string // Authorization header from the SSE connection
+}
+
 // SSETransport handles MCP communication over Server-Sent Events.
 type SSETransport struct {
 	mountPath   string
 	handlers    map[string]MessageHandler
-	connections map[string]chan *types.MCPMessage
+	connections map[string]*ConnectionContext
 	hMu         sync.RWMutex // Mutex for handlers map
 	cMu         sync.RWMutex // Mutex for connections map
 }
@@ -42,7 +48,7 @@ func NewSSETransport(mountPath string) *SSETransport {
 	return &SSETransport{
 		mountPath:   mountPath,
 		handlers:    make(map[string]MessageHandler),
-		connections: make(map[string]chan *types.MCPMessage),
+		connections: make(map[string]*ConnectionContext),
 	}
 }
 
@@ -71,7 +77,7 @@ func (s *SSETransport) HandleConnection(c *gin.Context) {
 		if isDebugMode() {
 			log.Printf("[SSE] Connection %s already exists, closing old connection", connID)
 		}
-		close(existingChan)
+		close(existingChan.Channel)
 		s.RemoveConnection(connID)
 	}
 
@@ -85,11 +91,20 @@ func (s *SSETransport) HandleConnection(c *gin.Context) {
 	h.Set("Access-Control-Expose-Headers", "X-Connection-ID")
 	h.Set("X-Connection-ID", connID)
 
+	// Capture Authorization header for forwarding to tool execution
+	authHeader := c.Request.Header.Get("Authorization")
+
 	// Create buffered channel for messages
 	msgChan := make(chan *types.MCPMessage, 100)
 
+	// Create connection context with auth header
+	connCtx := &ConnectionContext{
+		Channel:    msgChan,
+		AuthHeader: authHeader,
+	}
+
 	// Add connection to registry
-	s.AddConnection(connID, msgChan)
+	s.AddConnection(connID, connCtx)
 
 	// Create a context with cancel for coordinating goroutines
 	ctx, cancel := context.WithCancel(c.Request.Context())
@@ -264,7 +279,7 @@ func (s *SSETransport) HandleMessage(c *gin.Context) {
 
 	// Check if connection exists
 	s.cMu.RLock()
-	msgChan, exists := s.connections[connID]
+	connCtx, exists := s.connections[connID]
 	activeConnections := s.getActiveConnections() // Get active connections for logging
 	s.cMu.RUnlock()
 
@@ -280,12 +295,23 @@ func (s *SSETransport) HandleMessage(c *gin.Context) {
 		return
 	}
 
+	// Extract message channel from connection context
+	msgChan := connCtx.Channel
+
 	// Read and parse message
 	var reqMsg types.MCPMessage
 	if err := c.ShouldBindJSON(&reqMsg); err != nil {
 		log.Errorf("[SSE] Failed to parse message: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid message format: %v", err)})
 		return
+	}
+
+	// Inject connection ID into message for auth forwarding
+	// Add _mcpConnectionID to params if params is a map
+	if reqMsg.Params != nil {
+		if paramsMap, ok := reqMsg.Params.(map[string]interface{}); ok {
+			paramsMap["_mcpConnectionID"] = connID
+		}
 	}
 
 	// Find handler
@@ -358,11 +384,11 @@ func (s *SSETransport) RegisterHandler(method string, handler MessageHandler) {
 	}
 }
 
-// AddConnection adds a connection channel to the map.
-func (s *SSETransport) AddConnection(connID string, msgChan chan *types.MCPMessage) {
+// AddConnection adds a connection context to the map.
+func (s *SSETransport) AddConnection(connID string, connCtx *ConnectionContext) {
 	s.cMu.Lock()
 	defer s.cMu.Unlock()
-	s.connections[connID] = msgChan
+	s.connections[connID] = connCtx
 	if isDebugMode() {
 		log.Printf("[Transport DEBUG] Added connection %s. Total: %d", connID, len(s.connections))
 	}
@@ -381,6 +407,17 @@ func (s *SSETransport) RemoveConnection(connID string) {
 	}
 }
 
+// GetAuthHeader retrieves the Authorization header for a connection.
+// Returns empty string if connection not found or no auth header was provided.
+func (s *SSETransport) GetAuthHeader(connID string) string {
+	s.cMu.RLock()
+	defer s.cMu.RUnlock()
+	if connCtx, exists := s.connections[connID]; exists {
+		return connCtx.AuthHeader
+	}
+	return ""
+}
+
 // NotifyToolsChanged sends a tools/listChanged notification to all connected clients.
 func (s *SSETransport) NotifyToolsChanged() {
 	notification := &types.MCPMessage{
@@ -392,8 +429,8 @@ func (s *SSETransport) NotifyToolsChanged() {
 	numConns := len(s.connections)
 	channels := make([]chan *types.MCPMessage, 0, numConns)
 	connIDs := make([]string, 0, numConns)
-	for id, ch := range s.connections {
-		channels = append(channels, ch)
+	for id, connCtx := range s.connections {
+		channels = append(channels, connCtx.Channel)
 		connIDs = append(connIDs, id)
 	}
 	s.cMu.RUnlock()

--- a/pkg/transport/sse_test.go
+++ b/pkg/transport/sse_test.go
@@ -109,13 +109,13 @@ func TestSSETransport_AddRemoveConnection(t *testing.T) {
 	msgChan := make(chan *types.MCPMessage, 1)
 
 	// Add
-	s.AddConnection(connID, msgChan)
+	s.AddConnection(connID, &ConnectionContext{Channel: msgChan})
 	s.cMu.RLock()
-	retrievedChan, exists := s.connections[connID]
+	retrievedCtx, exists := s.connections[connID]
 	s.cMu.RUnlock()
 
 	assert.True(t, exists, "Connection should exist after adding")
-	assert.Equal(t, msgChan, retrievedChan, "Retrieved channel should match added channel")
+	assert.Equal(t, msgChan, retrievedCtx.Channel, "Retrieved channel should match added channel")
 
 	// Remove the connection
 	s.RemoveConnection(connID)
@@ -161,10 +161,10 @@ func TestSSETransport_HandleConnection(t *testing.T) {
 
 	// Verify connection was added
 	s.cMu.RLock()
-	msgChan, exists := s.connections[testSessionId]
+	connCtx, exists := s.connections[testSessionId]
 	s.cMu.RUnlock()
 	assert.True(t, exists, "Connection should be added")
-	assert.NotNil(t, msgChan)
+	assert.NotNil(t, connCtx)
 
 	// Verify headers (Check immediately after connection is confirmed, but acknowledge potential race)
 	// A more robust test might use channels to signal header writing completion.
@@ -175,7 +175,7 @@ func TestSSETransport_HandleConnection(t *testing.T) {
 
 	// Send a message to the connection
 	testMsg := &types.MCPMessage{Jsonrpc: "2.0", ID: types.RawMessage(`"test-id"`), Result: "test result"}
-	msgChan <- testMsg
+	connCtx.Channel <- testMsg
 
 	// Simulate client disconnect by cancelling the request context passed to HandleConnection
 	cancel() // Call the cancel function returned by setupTestGinContext
@@ -244,7 +244,7 @@ func TestSSETransport_HandleConnection_ExistingSession(t *testing.T) {
 	s := setupTestSSETransport("/mcp/events")
 	testSessionId := "existing-session-123"
 	oldChan := make(chan *types.MCPMessage, 1)
-	s.AddConnection(testSessionId, oldChan) // Add the "old" connection
+	s.AddConnection(testSessionId, &ConnectionContext{Channel: oldChan}) // Add the "old" connection
 
 	c, _, cancel := setupTestGinContext("GET", "/mcp/events", nil, map[string]string{"sessionId": testSessionId})
 
@@ -297,7 +297,7 @@ func TestSSETransport_HandleMessage_Success(t *testing.T) {
 	s := setupTestSSETransport("/mcp")
 	connID := "test-conn-handle-msg"
 	msgChan := make(chan *types.MCPMessage, 1)
-	s.AddConnection(connID, msgChan)
+	s.AddConnection(connID, &ConnectionContext{Channel: msgChan})
 	defer s.RemoveConnection(connID)
 
 	method := "test/success"
@@ -334,7 +334,7 @@ func TestSSETransport_HandleMessage_NoConnectionIdHeader(t *testing.T) {
 	s := setupTestSSETransport("/mcp")
 	connID := "test-conn-query"
 	msgChan := make(chan *types.MCPMessage, 1)
-	s.AddConnection(connID, msgChan)
+	s.AddConnection(connID, &ConnectionContext{Channel: msgChan})
 	defer s.RemoveConnection(connID)
 
 	method := "test/query"
@@ -393,7 +393,7 @@ func TestSSETransport_HandleMessage_BadRequestBody(t *testing.T) {
 	s := setupTestSSETransport("/mcp")
 	connID := "test-conn-bad-body"
 	msgChan := make(chan *types.MCPMessage, 1)
-	s.AddConnection(connID, msgChan)
+	s.AddConnection(connID, &ConnectionContext{Channel: msgChan})
 	defer s.RemoveConnection(connID)
 
 	reqBody := `{"jsonrpc":"2.0",,"id":"invalid"}` // Invalid JSON
@@ -419,7 +419,7 @@ func TestSSETransport_HandleMessage_HandlerNotFound(t *testing.T) {
 	s := setupTestSSETransport("/mcp")
 	connID := "test-conn-handler-nf"
 	msgChan := make(chan *types.MCPMessage, 1)
-	s.AddConnection(connID, msgChan)
+	s.AddConnection(connID, &ConnectionContext{Channel: msgChan})
 	defer s.RemoveConnection(connID)
 
 	reqBody := `{"jsonrpc":"2.0","id":"req-id-4","method":"unregistered/method","params":{}}`
@@ -483,8 +483,8 @@ func TestSSETransport_NotifyToolsChanged(t *testing.T) {
 	msgChan1 := make(chan *types.MCPMessage, 1)
 	msgChan2 := make(chan *types.MCPMessage, 1)
 
-	s.AddConnection(connID1, msgChan1)
-	s.AddConnection(connID2, msgChan2)
+	s.AddConnection(connID1, &ConnectionContext{Channel: msgChan1})
+	s.AddConnection(connID2, &ConnectionContext{Channel: msgChan2})
 	defer s.RemoveConnection(connID1)
 	defer s.RemoveConnection(connID2)
 

--- a/pkg/transport/streamable_http.go
+++ b/pkg/transport/streamable_http.go
@@ -1,0 +1,313 @@
+package transport
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+// StreamableHTTPTransport handles MCP communication over Streamable HTTP (MCP spec 2025-03-26).
+//
+// Unlike SSE transport, this is stateless: POST requests return JSON responses directly in the
+// HTTP body. No persistent SSE connection is required before sending messages, which means:
+//   - Works transparently with any load balancer (no pod affinity required)
+//   - Fully compatible with horizontal autoscaling
+//   - No connection state to manage or reconnect
+//
+// An optional GET endpoint is provided for server-initiated notifications. Clients that
+// need push notifications (e.g. tools/listChanged) can open an SSE session via GET with
+// the Mcp-Session-Id header. This is not required for basic request-response operation.
+//
+// Security: if AllowedOrigins is non-empty, any request carrying an Origin header whose
+// value is not in the allowlist is rejected with 403 Forbidden. This prevents DNS rebinding
+// attacks. Server-to-server calls that omit the Origin header are always permitted.
+type StreamableHTTPTransport struct {
+	mountPath      string
+	allowedOrigins []string // nil/empty = allow all origins
+	handlers       map[string]MessageHandler
+	hMu            sync.RWMutex
+	// Transient per-request auth headers: request UUID → Authorization header value.
+	// Populated at the start of HandleMessage and deleted when the handler returns.
+	requestAuths map[string]string
+	rMu          sync.RWMutex
+	// Optional SSE sessions for server-initiated notifications: Mcp-Session-Id → session.
+	sessions map[string]*streamableSession
+	sMu      sync.RWMutex
+}
+
+type streamableSession struct {
+	Channel chan *types.MCPMessage
+}
+
+// NewStreamableHTTPTransport creates a new StreamableHTTPTransport mounted at mountPath.
+//
+// allowedOrigins is an optional list of permitted Origin header values (e.g.
+// ["https://app.example.com"]). Pass nil or an empty slice to allow all origins.
+// When non-empty, requests with an Origin header not in the list are rejected with
+// 403 Forbidden. Server-to-server requests without an Origin header are always allowed.
+func NewStreamableHTTPTransport(mountPath string, allowedOrigins []string) *StreamableHTTPTransport {
+	if isDebugMode() {
+		log.Infof("[StreamableHTTP] Creating new transport at %s", mountPath)
+		if len(allowedOrigins) > 0 {
+			log.Infof("[StreamableHTTP] Origin allowlist: %v", allowedOrigins)
+		} else {
+			log.Infof("[StreamableHTTP] No Origin allowlist configured — all origins permitted")
+		}
+	}
+	return &StreamableHTTPTransport{
+		mountPath:      mountPath,
+		allowedOrigins: allowedOrigins,
+		handlers:       make(map[string]MessageHandler),
+		requestAuths:   make(map[string]string),
+		sessions:       make(map[string]*streamableSession),
+	}
+}
+
+// RegisterHandler registers a handler for a specific MCP method.
+func (s *StreamableHTTPTransport) RegisterHandler(method string, handler MessageHandler) {
+	s.hMu.Lock()
+	defer s.hMu.Unlock()
+	s.handlers[method] = handler
+	if isDebugMode() {
+		log.Printf("[StreamableHTTP] Registered handler for method: %s", method)
+	}
+}
+
+// isOriginAllowed checks whether the given Origin value is permitted.
+// Returns true if the allowlist is empty (all origins allowed) or the origin is in the list.
+// An empty origin string (absent header) is always allowed — it indicates a server-to-server call.
+func (s *StreamableHTTPTransport) isOriginAllowed(origin string) bool {
+	if origin == "" {
+		// No Origin header: server-to-server call (e.g. curl, Node.js) — always permit.
+		return true
+	}
+	if len(s.allowedOrigins) == 0 {
+		// No allowlist configured — allow all origins.
+		return true
+	}
+	for _, allowed := range s.allowedOrigins {
+		if allowed == origin {
+			return true
+		}
+	}
+	return false
+}
+
+// corsOriginHeader returns the value to use for the Access-Control-Allow-Origin response header.
+// Echoes the request origin back when it is in the allowlist; falls back to "*" when there is
+// no allowlist (open access) or origin is absent.
+func (s *StreamableHTTPTransport) corsOriginHeader(requestOrigin string) string {
+	if requestOrigin != "" && len(s.allowedOrigins) > 0 {
+		return requestOrigin
+	}
+	return "*"
+}
+
+// isNotification reports whether an MCPMessage is a JSON-RPC notification or response (i.e.
+// has no id field). Per MCP spec 2025-03-26, pure notifications/responses must receive a
+// 202 Accepted with no body rather than a JSON-RPC response.
+func isNotification(msg *types.MCPMessage) bool {
+	return len(msg.ID) == 0 || string(msg.ID) == "null"
+}
+
+// HandleConnection handles GET requests for server-initiated SSE notifications (optional).
+// Clients that need push notifications (e.g. tools/listChanged) should connect with an
+// Mcp-Session-Id header. Basic request-response usage does not require this endpoint.
+func (s *StreamableHTTPTransport) HandleConnection(c *gin.Context) {
+	// --- Origin validation (DNS rebinding protection, MCP spec 2025-03-26 §Security) ---
+	origin := c.Request.Header.Get("Origin")
+	if !s.isOriginAllowed(origin) {
+		log.Warnf("[StreamableHTTP] Rejected GET from disallowed origin: %q", origin)
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Origin not allowed"})
+		return
+	}
+
+	sessionID := c.GetHeader("Mcp-Session-Id")
+	if sessionID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing Mcp-Session-Id header"})
+		return
+	}
+
+	if isDebugMode() {
+		log.Printf("[StreamableHTTP] SSE session opened: %s", sessionID)
+	}
+
+	h := c.Writer.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	// Echo back the validated origin rather than broadcasting "*".
+	h.Set("Access-Control-Allow-Origin", s.corsOriginHeader(origin))
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Streaming not supported"})
+		return
+	}
+
+	msgChan := make(chan *types.MCPMessage, 100)
+	sess := &streamableSession{Channel: msgChan}
+
+	s.sMu.Lock()
+	s.sessions[sessionID] = sess
+	s.sMu.Unlock()
+
+	defer func() {
+		s.sMu.Lock()
+		delete(s.sessions, sessionID)
+		s.sMu.Unlock()
+		close(msgChan)
+		if isDebugMode() {
+			log.Printf("[StreamableHTTP] SSE session closed: %s", sessionID)
+		}
+	}()
+
+	ticker := time.NewTicker(keepAliveInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			return
+		case <-ticker.C:
+			fmt.Fprintf(c.Writer, ": ping\n\n")
+			flusher.Flush()
+		case msg, ok := <-msgChan:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(msg)
+			if err != nil {
+				log.Errorf("[StreamableHTTP] Failed to marshal notification: %v", err)
+				continue
+			}
+			fmt.Fprintf(c.Writer, "event: message\ndata: %s\n\n", string(data))
+			flusher.Flush()
+		}
+	}
+}
+
+// HandleMessage processes POST requests containing JSON-RPC messages.
+//
+// Per MCP spec 2025-03-26:
+//   - If the message is a JSON-RPC request (has an id), the handler is invoked and the
+//     JSON-RPC response is returned directly in the HTTP body (Content-Type: application/json).
+//   - If the message is a JSON-RPC notification or response (no id), 202 Accepted is returned
+//     with no body.
+//
+// No prior SSE connection is needed — every POST is handled independently.
+func (s *StreamableHTTPTransport) HandleMessage(c *gin.Context) {
+	// --- Origin validation (DNS rebinding protection, MCP spec 2025-03-26 §Security) ---
+	origin := c.Request.Header.Get("Origin")
+	if !s.isOriginAllowed(origin) {
+		log.Warnf("[StreamableHTTP] Rejected POST from disallowed origin: %q", origin)
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Origin not allowed"})
+		return
+	}
+
+	// Assign a short-lived request ID to support auth header forwarding.
+	requestID := uuid.New().String()
+	authHeader := c.Request.Header.Get("Authorization")
+
+	s.rMu.Lock()
+	s.requestAuths[requestID] = authHeader
+	s.rMu.Unlock()
+	defer func() {
+		s.rMu.Lock()
+		delete(s.requestAuths, requestID)
+		s.rMu.Unlock()
+	}()
+
+	var reqMsg types.MCPMessage
+	if err := c.ShouldBindJSON(&reqMsg); err != nil {
+		log.Errorf("[StreamableHTTP] Failed to parse message: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid message format: %v", err)})
+		return
+	}
+
+	if isDebugMode() {
+		log.Printf("[StreamableHTTP] Received method=%s id=%v", reqMsg.Method, reqMsg.ID)
+	}
+
+	// Per MCP spec 2025-03-26: notifications and responses (no id) must receive 202 Accepted
+	// with no body — they do not expect a JSON-RPC reply.
+	if isNotification(&reqMsg) {
+		if isDebugMode() {
+			log.Printf("[StreamableHTTP] Notification received (method=%s), returning 202", reqMsg.Method)
+		}
+		c.Status(http.StatusAccepted)
+		return
+	}
+
+	// Inject the request ID so that executeToolLogic can retrieve the auth header
+	// via GetAuthHeader(requestID) when ForwardAuthHeaders is enabled.
+	if reqMsg.Params == nil {
+		reqMsg.Params = map[string]interface{}{}
+	}
+	if paramsMap, ok := reqMsg.Params.(map[string]interface{}); ok {
+		paramsMap["_mcpConnectionID"] = requestID
+	}
+
+	s.hMu.RLock()
+	handler, found := s.handlers[reqMsg.Method]
+	s.hMu.RUnlock()
+
+	if !found {
+		if isDebugMode() {
+			log.Printf("[StreamableHTTP] No handler for method: %s", reqMsg.Method)
+		}
+		c.JSON(http.StatusOK, &types.MCPMessage{
+			Jsonrpc: "2.0",
+			ID:      reqMsg.ID,
+			Error: map[string]interface{}{
+				"code":    -32601,
+				"message": fmt.Sprintf("Method '%s' not found", reqMsg.Method),
+			},
+		})
+		return
+	}
+
+	respMsg := handler(&reqMsg)
+	c.JSON(http.StatusOK, respMsg)
+}
+
+// GetAuthHeader returns the Authorization header captured during the current POST request.
+// requestID is the UUID injected as _mcpConnectionID by HandleMessage.
+func (s *StreamableHTTPTransport) GetAuthHeader(requestID string) string {
+	s.rMu.RLock()
+	defer s.rMu.RUnlock()
+	return s.requestAuths[requestID]
+}
+
+// NotifyToolsChanged sends a tools/listChanged notification to all open SSE sessions.
+func (s *StreamableHTTPTransport) NotifyToolsChanged() {
+	notification := &types.MCPMessage{
+		Jsonrpc: "2.0",
+		Method:  "notifications/tools/listChanged",
+	}
+
+	s.sMu.RLock()
+	sessions := make([]*streamableSession, 0, len(s.sessions))
+	for _, sess := range s.sessions {
+		sessions = append(sessions, sess)
+	}
+	s.sMu.RUnlock()
+
+	if isDebugMode() {
+		log.Printf("[StreamableHTTP] Notifying %d SSE sessions about tools change", len(sessions))
+	}
+
+	for _, sess := range sessions {
+		select {
+		case sess.Channel <- notification:
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/pkg/transport/streamable_http_test.go
+++ b/pkg/transport/streamable_http_test.go
@@ -1,0 +1,761 @@
+package transport
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test Setup ---
+
+func setupTestStreamableHTTPTransport(mountPath string, allowedOrigins []string) *StreamableHTTPTransport {
+	setGinModeOnce.Do(func() {}) // Already called by sse_test.go if tests run together; safe to call again via Once.
+	return NewStreamableHTTPTransport(mountPath, allowedOrigins)
+}
+
+// --- Constructor & RegisterHandler ---
+
+func TestNewStreamableHTTPTransport(t *testing.T) {
+	mountPath := "/mcp"
+	s := NewStreamableHTTPTransport(mountPath, nil)
+
+	assert.NotNil(t, s)
+	assert.Equal(t, mountPath, s.mountPath)
+	assert.NotNil(t, s.handlers)
+	assert.Empty(t, s.handlers)
+	assert.NotNil(t, s.requestAuths)
+	assert.Empty(t, s.requestAuths)
+	assert.NotNil(t, s.sessions)
+	assert.Empty(t, s.sessions)
+	assert.Empty(t, s.allowedOrigins)
+}
+
+func TestNewStreamableHTTPTransport_WithAllowedOrigins(t *testing.T) {
+	origins := []string{"https://app.example.com", "https://other.example.com"}
+	s := NewStreamableHTTPTransport("/mcp", origins)
+
+	assert.NotNil(t, s)
+	assert.Equal(t, origins, s.allowedOrigins)
+}
+
+func TestStreamableHTTPTransport_RegisterHandler(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	method := "test/method"
+	handler := func(msg *types.MCPMessage) *types.MCPMessage {
+		return &types.MCPMessage{Result: "ok"}
+	}
+
+	s.RegisterHandler(method, handler)
+
+	s.hMu.RLock()
+	registeredHandler, exists := s.handlers[method]
+	s.hMu.RUnlock()
+
+	assert.True(t, exists, "Handler should be registered")
+	assert.NotNil(t, registeredHandler)
+
+	// Test overwriting a handler
+	newHandler := func(msg *types.MCPMessage) *types.MCPMessage {
+		return &types.MCPMessage{Result: "new ok"}
+	}
+	s.RegisterHandler(method, newHandler)
+	s.hMu.RLock()
+	overwrittenHandler, _ := s.handlers[method]
+	s.hMu.RUnlock()
+	resp := overwrittenHandler(&types.MCPMessage{})
+	assert.Equal(t, "new ok", resp.Result)
+}
+
+// --- Origin helpers ---
+
+func TestStreamableHTTPTransport_IsOriginAllowed(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedOrigins []string
+		requestOrigin  string
+		want           bool
+	}{
+		{"empty origin always allowed", []string{"https://allowed.example.com"}, "", true},
+		{"no allowlist permits all origins", nil, "https://any.example.com", true},
+		{"empty allowlist permits all origins", []string{}, "https://any.example.com", true},
+		{"origin in allowlist", []string{"https://allowed.example.com"}, "https://allowed.example.com", true},
+		{"origin not in allowlist", []string{"https://allowed.example.com"}, "https://evil.example.com", false},
+		{"one of many origins matches", []string{"https://a.com", "https://b.com"}, "https://b.com", true},
+		{"no match in multi-origin list", []string{"https://a.com", "https://b.com"}, "https://c.com", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewStreamableHTTPTransport("/mcp", tc.allowedOrigins)
+			got := s.isOriginAllowed(tc.requestOrigin)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestStreamableHTTPTransport_CorsOriginHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedOrigins []string
+		requestOrigin  string
+		want           string
+	}{
+		{"no allowlist, no origin → wildcard", nil, "", "*"},
+		{"no allowlist, origin present → wildcard", nil, "https://app.example.com", "*"},
+		{"allowlist configured, origin present → echo origin", []string{"https://app.example.com"}, "https://app.example.com", "https://app.example.com"},
+		{"allowlist configured, no origin → wildcard", []string{"https://app.example.com"}, "", "*"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewStreamableHTTPTransport("/mcp", tc.allowedOrigins)
+			got := s.corsOriginHeader(tc.requestOrigin)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// --- isNotification helper ---
+
+func TestIsNotification(t *testing.T) {
+	assert.True(t, isNotification(&types.MCPMessage{ID: nil}), "nil ID should be a notification")
+	assert.True(t, isNotification(&types.MCPMessage{ID: types.RawMessage(`null`)}), "null ID should be a notification")
+	assert.False(t, isNotification(&types.MCPMessage{ID: types.RawMessage(`"1"`)}), "string ID should not be a notification")
+	assert.False(t, isNotification(&types.MCPMessage{ID: types.RawMessage(`1`)}), "numeric ID should not be a notification")
+}
+
+// --- HandleMessage ---
+
+func TestStreamableHTTPTransport_HandleMessage_Success(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	method := "test/success"
+	handlerCalled := false
+	s.RegisterHandler(method, func(msg *types.MCPMessage) *types.MCPMessage {
+		handlerCalled = true
+		assert.Equal(t, method, msg.Method)
+		assert.Equal(t, types.RawMessage(`"req-id-1"`), msg.ID)
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "handler success"}
+	})
+
+	reqBody := `{"jsonrpc":"2.0","id":"req-id-1","method":"test/success","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, handlerCalled, "Registered handler should have been called")
+	assert.Contains(t, w.Body.String(), `"result":"handler success"`)
+	assert.Contains(t, w.Body.String(), `"id":"req-id-1"`)
+}
+
+func TestStreamableHTTPTransport_HandleMessage_Notification(t *testing.T) {
+	// JSON-RPC messages with no ID (notifications) must return 202 Accepted with no body.
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	handlerCalled := false
+	s.RegisterHandler("notifications/cancelled", func(msg *types.MCPMessage) *types.MCPMessage {
+		handlerCalled = true
+		return nil
+	})
+
+	reqBody := `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	// c.Status() sets gin's internal status but does not flush to the ResponseRecorder
+	// when the handler is invoked directly (bypassing gin's ServeHTTP). In production,
+	// ServeHTTP calls WriteHeaderNow() after the handler returns, which propagates the
+	// status. We therefore check c.Writer.Status() (the gin-level status) rather than
+	// w.Code (the recorder-level status, which stays at 200 until flushed).
+	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	assert.Empty(t, w.Body.String(), "202 response must have no body")
+	assert.False(t, handlerCalled, "Handler should not be called for notifications")
+}
+
+func TestStreamableHTTPTransport_HandleMessage_NullID(t *testing.T) {
+	// Explicit null id also counts as a notification.
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	reqBody := `{"jsonrpc":"2.0","id":null,"method":"some/notification"}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	// See comment in TestStreamableHTTPTransport_HandleMessage_Notification about why
+	// we check c.Writer.Status() rather than w.Code here.
+	assert.Equal(t, http.StatusAccepted, c.Writer.Status())
+	assert.Empty(t, w.Body.String(), "null-id message must have no body")
+}
+
+func TestStreamableHTTPTransport_HandleMessage_BadRequestBody(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	reqBody := `{"jsonrpc":"2.0",,"id":"invalid"}` // Invalid JSON
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid message format")
+}
+
+func TestStreamableHTTPTransport_HandleMessage_HandlerNotFound(t *testing.T) {
+	// Unlike SSE, the error is returned directly in the HTTP body (200 OK with JSON-RPC error).
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	reqBody := `{"jsonrpc":"2.0","id":"req-id-nf","method":"unregistered/method","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"id":"req-id-nf"`)
+	assert.Contains(t, body, `"code":-32601`)
+	assert.Contains(t, body, "not found")
+}
+
+func TestStreamableHTTPTransport_HandleMessage_DisallowedOrigin(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", []string{"https://allowed.example.com"})
+
+	reqBody := `{"jsonrpc":"2.0","id":"1","method":"test/method","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Origin", "https://evil.example.com")
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Origin not allowed")
+}
+
+func TestStreamableHTTPTransport_HandleMessage_AllowedOriginPermitted(t *testing.T) {
+	allowedOrigin := "https://app.example.com"
+	s := setupTestStreamableHTTPTransport("/mcp", []string{allowedOrigin})
+	s.RegisterHandler("test/method", func(msg *types.MCPMessage) *types.MCPMessage {
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
+	})
+
+	reqBody := `{"jsonrpc":"2.0","id":"1","method":"test/method","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Origin", allowedOrigin)
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestStreamableHTTPTransport_HandleMessage_NoOriginAlwaysPermitted(t *testing.T) {
+	// Server-to-server calls without Origin header must always be allowed.
+	s := setupTestStreamableHTTPTransport("/mcp", []string{"https://allowed.example.com"})
+	s.RegisterHandler("test/method", func(msg *types.MCPMessage) *types.MCPMessage {
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
+	})
+
+	reqBody := `{"jsonrpc":"2.0","id":"1","method":"test/method","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	// No Origin header set — simulates a server-to-server call.
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Auth header forwarding ---
+
+func TestStreamableHTTPTransport_GetAuthHeader(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	authValue := "Bearer test-token-xyz"
+
+	var capturedRequestID string
+	s.RegisterHandler("test/auth", func(msg *types.MCPMessage) *types.MCPMessage {
+		paramsMap, ok := msg.Params.(map[string]interface{})
+		require.True(t, ok, "Params should be a map")
+		id, ok := paramsMap["_mcpConnectionID"].(string)
+		require.True(t, ok, "_mcpConnectionID should be a string")
+		capturedRequestID = id
+		// While the handler is running, the auth header must be retrievable.
+		assert.Equal(t, authValue, s.GetAuthHeader(id), "Auth header should be retrievable inside handler")
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
+	})
+
+	reqBody := `{"jsonrpc":"2.0","id":"1","method":"test/auth","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Authorization", authValue)
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NotEmpty(t, capturedRequestID, "Handler should have captured a request ID")
+
+	// After the request completes, the entry must be cleaned up (defer in HandleMessage).
+	assert.Empty(t, s.GetAuthHeader(capturedRequestID), "Auth header should be removed after request completes")
+}
+
+func TestStreamableHTTPTransport_GetAuthHeader_MissingToken(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	// Unknown request ID returns empty string.
+	assert.Empty(t, s.GetAuthHeader("non-existent-uuid"))
+}
+
+func TestStreamableHTTPTransport_MCPConnectionID_InjectedIntoParams(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	var receivedParams map[string]interface{}
+	s.RegisterHandler("test/params", func(msg *types.MCPMessage) *types.MCPMessage {
+		paramsMap, ok := msg.Params.(map[string]interface{})
+		require.True(t, ok)
+		receivedParams = paramsMap
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
+	})
+
+	reqBody := `{"jsonrpc":"2.0","id":"1","method":"test/params","params":{"custom":"value"}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, receivedParams)
+	assert.Equal(t, "value", receivedParams["custom"], "Original params must be preserved")
+	assert.NotEmpty(t, receivedParams["_mcpConnectionID"], "_mcpConnectionID must be injected")
+}
+
+func TestStreamableHTTPTransport_MCPConnectionID_InjectedWhenParamsNil(t *testing.T) {
+	// If the message has no params field, HandleMessage must still inject _mcpConnectionID.
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	var receivedParams map[string]interface{}
+	s.RegisterHandler("test/nilparams", func(msg *types.MCPMessage) *types.MCPMessage {
+		paramsMap, ok := msg.Params.(map[string]interface{})
+		require.True(t, ok, "Params should be initialised as a map even when absent in request")
+		receivedParams = paramsMap
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
+	})
+
+	// No "params" field in the request body.
+	reqBody := `{"jsonrpc":"2.0","id":"1","method":"test/nilparams"}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, receivedParams)
+	assert.NotEmpty(t, receivedParams["_mcpConnectionID"])
+}
+
+// --- HandleConnection (optional SSE for server push) ---
+
+func TestStreamableHTTPTransport_HandleConnection_MissingSessionID(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	// No Mcp-Session-Id header.
+	c, w, cancel := setupTestGinContext("GET", "/mcp", nil, nil)
+	defer cancel()
+
+	s.HandleConnection(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Missing Mcp-Session-Id header")
+}
+
+func TestStreamableHTTPTransport_HandleConnection_DisallowedOrigin(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", []string{"https://allowed.example.com"})
+	c, w, cancel := setupTestGinContext("GET", "/mcp", nil, nil)
+	defer cancel()
+	c.Request.Header.Set("Mcp-Session-Id", "some-session")
+	c.Request.Header.Set("Origin", "https://evil.example.com")
+
+	s.HandleConnection(c)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Origin not allowed")
+}
+
+func TestStreamableHTTPTransport_HandleConnection_SSEHeaders(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	sessionID := "test-session-sse"
+
+	c, w, cancel := setupTestGinContext("GET", "/mcp", nil, nil)
+	c.Request.Header.Set("Mcp-Session-Id", sessionID)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.HandleConnection(c)
+	}()
+
+	// Wait until the session is registered — this happens *after* the response headers are
+	// written, giving us a race-free synchronisation point instead of an arbitrary sleep.
+	require.Eventually(t, func() bool {
+		s.sMu.RLock()
+		defer s.sMu.RUnlock()
+		_, ok := s.sessions[sessionID]
+		return ok
+	}, time.Second, 5*time.Millisecond, "Session should be registered")
+
+	// Headers are stable once the session is registered — safe to read without a race.
+	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+	assert.Equal(t, "no-cache", w.Header().Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", w.Header().Get("Connection"))
+
+	cancel()
+	wg.Wait()
+
+	// Session must be cleaned up after disconnect.
+	s.sMu.RLock()
+	_, existsAfter := s.sessions[sessionID]
+	s.sMu.RUnlock()
+	assert.False(t, existsAfter, "Session should be removed after HandleConnection returns")
+}
+
+func TestStreamableHTTPTransport_HandleConnection_SendsMessage(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	sessionID := "session-msg-test"
+
+	c, w, cancel := setupTestGinContext("GET", "/mcp", nil, nil)
+	c.Request.Header.Set("Mcp-Session-Id", sessionID)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.HandleConnection(c)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Retrieve the session channel and push a notification.
+	s.sMu.RLock()
+	sess, exists := s.sessions[sessionID]
+	s.sMu.RUnlock()
+	require.True(t, exists, "Session must exist before sending")
+
+	testMsg := &types.MCPMessage{
+		Jsonrpc: "2.0",
+		Method:  "notifications/tools/listChanged",
+	}
+	sess.Channel <- testMsg
+
+	// Give the goroutine time to write the event.
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	wg.Wait()
+
+	body, _ := io.ReadAll(w.Body)
+	bodyStr := string(body)
+	assert.Contains(t, bodyStr, "event: message")
+	assert.Contains(t, bodyStr, `"method":"notifications/tools/listChanged"`)
+}
+
+func TestStreamableHTTPTransport_HandleConnection_DuplicateSessionID(t *testing.T) {
+	// When a client reconnects with the same Mcp-Session-Id while a session is already
+	// open, Streamable HTTP silently overwrites the sessions map entry.
+	//
+	// This is notably different from SSE transport, which explicitly closes the old channel
+	// and removes the old entry before setting up the new connection (sse.go:76-82).
+	//
+	// Consequence: the old goroutine's deferred delete(s.sessions, sessionID) will remove
+	// the *new* session from the map when the old goroutine eventually finishes — meaning
+	// any NotifyToolsChanged calls sent after the old goroutine exits will not reach the
+	// active client.
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	sessionID := "duplicate-session"
+
+	// Simulate an already-open session by injecting it directly, as the SSE test does.
+	oldChan := make(chan *types.MCPMessage, 1)
+	s.sMu.Lock()
+	s.sessions[sessionID] = &streamableSession{Channel: oldChan}
+	s.sMu.Unlock()
+
+	c, _, cancel := setupTestGinContext("GET", "/mcp", nil, nil)
+	c.Request.Header.Set("Mcp-Session-Id", sessionID)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.HandleConnection(c)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Unlike SSE transport, the old channel is NOT closed on reconnect — it is only
+	// abandoned (and will remain open until the old goroutine's context is cancelled).
+	oldChanStillOpen := true
+	select {
+	case _, ok := <-oldChan:
+		if !ok {
+			oldChanStillOpen = false
+		}
+	case <-time.After(50 * time.Millisecond):
+		// Timeout: channel is still open — expected for Streamable HTTP.
+	}
+	assert.True(t, oldChanStillOpen,
+		"Streamable HTTP does NOT close the old session channel on reconnect (unlike SSE)")
+
+	// The map now points to the new session.
+	s.sMu.RLock()
+	currentSess, exists := s.sessions[sessionID]
+	s.sMu.RUnlock()
+	assert.True(t, exists, "A session should still be registered under the same ID")
+	assert.NotEqual(t, oldChan, currentSess.Channel,
+		"The sessions map must point to the new session's channel, not the old one")
+
+	cancel()
+	wg.Wait()
+
+	// After the new goroutine's context is cancelled, its deferred cleanup removes the entry.
+	s.sMu.RLock()
+	_, existsAfter := s.sessions[sessionID]
+	s.sMu.RUnlock()
+	assert.False(t, existsAfter, "Session should be removed after HandleConnection returns")
+}
+
+func TestStreamableHTTPTransport_HandleConnection_CORSWithAllowedOrigin(t *testing.T) {
+	allowedOrigin := "https://app.example.com"
+	s := setupTestStreamableHTTPTransport("/mcp", []string{allowedOrigin})
+	sessionID := "session-cors"
+
+	c, w, cancel := setupTestGinContext("GET", "/mcp", nil, nil)
+	c.Request.Header.Set("Mcp-Session-Id", sessionID)
+	c.Request.Header.Set("Origin", allowedOrigin)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.HandleConnection(c)
+	}()
+
+	// Wait until the session is registered — headers are written before the session map
+	// is updated, so this is a race-free synchronisation point.
+	require.Eventually(t, func() bool {
+		s.sMu.RLock()
+		defer s.sMu.RUnlock()
+		_, ok := s.sessions[sessionID]
+		return ok
+	}, time.Second, 5*time.Millisecond, "Session should be registered")
+
+	// The response ACAO header must echo the validated origin, not "*".
+	assert.Equal(t, allowedOrigin, w.Header().Get("Access-Control-Allow-Origin"))
+
+	cancel()
+	wg.Wait()
+}
+
+// --- NotifyToolsChanged ---
+
+func TestStreamableHTTPTransport_NotifyToolsChanged(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	// Register two SSE sessions manually.
+	msgChan1 := make(chan *types.MCPMessage, 1)
+	msgChan2 := make(chan *types.MCPMessage, 1)
+
+	s.sMu.Lock()
+	s.sessions["session-1"] = &streamableSession{Channel: msgChan1}
+	s.sessions["session-2"] = &streamableSession{Channel: msgChan2}
+	s.sMu.Unlock()
+
+	s.NotifyToolsChanged()
+
+	receive := func(ch chan *types.MCPMessage) *types.MCPMessage {
+		select {
+		case msg := <-ch:
+			return msg
+		case <-time.After(200 * time.Millisecond):
+			return nil
+		}
+	}
+
+	msg1 := receive(msgChan1)
+	msg2 := receive(msgChan2)
+
+	require.NotNil(t, msg1, "Session 1 should receive a notification")
+	require.NotNil(t, msg2, "Session 2 should receive a notification")
+
+	assert.Equal(t, "notifications/tools/listChanged", msg1.Method)
+	assert.Equal(t, "2.0", msg1.Jsonrpc)
+	assert.Equal(t, "notifications/tools/listChanged", msg2.Method)
+}
+
+func TestStreamableHTTPTransport_NotifyToolsChanged_NoSessions(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	// No sessions registered — must not panic.
+	assert.NotPanics(t, func() { s.NotifyToolsChanged() })
+}
+
+// --- Concurrency ---
+
+func TestStreamableHTTPTransport_ConcurrentHandleMessage(t *testing.T) {
+	// Verify that concurrent POST requests do not race on the requestAuths map.
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	s.RegisterHandler("test/concurrent", func(msg *types.MCPMessage) *types.MCPMessage {
+		time.Sleep(5 * time.Millisecond) // simulate work
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
+	})
+
+	const numRequests = 20
+	var wg sync.WaitGroup
+	wg.Add(numRequests)
+
+	for i := 0; i < numRequests; i++ { //nolint:intrange
+		go func(i int) {
+			defer wg.Done()
+			reqBody := fmt.Sprintf(`{"jsonrpc":"2.0","id":"%d","method":"test/concurrent","params":{}}`, i)
+			c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+			c.Request.Header.Set("Content-Type", "application/json")
+			c.Request.Header.Set("Authorization", fmt.Sprintf("Bearer token-%d", i))
+			s.HandleMessage(c)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// After all requests complete, requestAuths must be empty (all cleaned up).
+	s.rMu.RLock()
+	remaining := len(s.requestAuths)
+	s.rMu.RUnlock()
+	assert.Zero(t, remaining, "requestAuths should be empty after all requests complete")
+}
+
+func TestStreamableHTTPTransport_ConcurrentRegisterHandler(t *testing.T) {
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s.RegisterHandler(fmt.Sprintf("method/%d", i), func(msg *types.MCPMessage) *types.MCPMessage {
+				return nil
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	s.hMu.RLock()
+	count := len(s.handlers)
+	s.hMu.RUnlock()
+	assert.Equal(t, 10, count)
+}
+
+// --- Stateless behaviour ---
+
+func TestStreamableHTTPTransport_StatelessRequests(t *testing.T) {
+	// Each POST is handled independently; no prior connection needed.
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	s.RegisterHandler("test/stateless", func(msg *types.MCPMessage) *types.MCPMessage {
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "stateless-ok"}
+	})
+
+	// Send three independent POSTs, each with a different ID.
+	for _, id := range []string{"a", "b", "c"} {
+		reqBody := fmt.Sprintf(`{"jsonrpc":"2.0","id":"%s","method":"test/stateless","params":{}}`, id)
+		c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		s.HandleMessage(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, fmt.Sprintf(`"id":"%s"`, id))
+		assert.Contains(t, body, `"result":"stateless-ok"`)
+	}
+
+	// No sessions or auth state should have accumulated.
+	s.sMu.RLock()
+	sessionCount := len(s.sessions)
+	s.sMu.RUnlock()
+	assert.Zero(t, sessionCount, "Stateless requests must not create SSE sessions")
+
+	s.rMu.RLock()
+	authCount := len(s.requestAuths)
+	s.rMu.RUnlock()
+	assert.Zero(t, authCount, "requestAuths must be empty after all requests complete")
+}
+
+// --- Response body contains correct CORS header for open access ---
+
+func TestStreamableHTTPTransport_HandleMessage_CORSWildcardWhenNoAllowlist(t *testing.T) {
+	// When there is no allowlist, Access-Control-Allow-Origin is not set by HandleMessage
+	// (it is only set by HandleConnection). This test documents the current behaviour:
+	// HandleMessage does not write CORS headers itself — that is the responsibility of
+	// any CORS middleware applied to the Gin router.
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+	s.RegisterHandler("test/cors", func(msg *types.MCPMessage) *types.MCPMessage {
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
+	})
+
+	reqBody := `{"jsonrpc":"2.0","id":"1","method":"test/cors","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Origin", "https://browser.example.com")
+
+	s.HandleMessage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	// HandleMessage does not set Access-Control-Allow-Origin for POST requests.
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+// --- Implements Transport interface ---
+
+func TestStreamableHTTPTransport_ImplementsTransportInterface(t *testing.T) {
+	// Compile-time check: StreamableHTTPTransport must satisfy the Transport interface.
+	var _ Transport = (*StreamableHTTPTransport)(nil)
+}
+
+// --- Long description test for tools/list method name collision ---
+
+func TestStreamableHTTPTransport_HandleMessage_ResponseDirectlyInBody(t *testing.T) {
+	// Verify that the response is returned synchronously in the HTTP response body,
+	// not via an SSE channel (key difference from SSE transport).
+	s := setupTestStreamableHTTPTransport("/mcp", nil)
+
+	expectedResult := "direct-body-response"
+	s.RegisterHandler("test/direct", func(msg *types.MCPMessage) *types.MCPMessage {
+		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: expectedResult}
+	})
+
+	reqBody := `{"jsonrpc":"2.0","id":"42","method":"test/direct","params":{}}`
+	c, w, _ := setupTestGinContext("POST", "/mcp", bytes.NewBufferString(reqBody), nil)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.HandleMessage(c)
+
+	// Must return 200 synchronously.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body := w.Body.String()
+	// Response body must contain the JSON-RPC result.
+	assert.True(t, strings.Contains(body, expectedResult), "Response body should contain the result directly")
+	assert.True(t, strings.Contains(body, `"id":"42"`), "Response body should contain the request ID")
+
+	// No SSE sessions should exist.
+	s.sMu.RLock()
+	assert.Empty(t, s.sessions, "No SSE session should be created for a POST request")
+	s.sMu.RUnlock()
+}

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -21,4 +21,7 @@ type Transport interface {
 
 	// NotifyToolsChanged sends a notification to connected clients that the tool list has changed.
 	NotifyToolsChanged()
+
+	// GetAuthHeader retrieves the Authorization header for a connection.
+	GetAuthHeader(connID string) string
 }

--- a/server.go
+++ b/server.go
@@ -45,6 +45,22 @@ type GinMCP struct {
 	executeToolFunc func(operationID string, parameters map[string]interface{}) (interface{}, error)
 }
 
+// TransportType selects the MCP transport protocol.
+type TransportType string
+
+const (
+	// TransportTypeSSE uses the original SSE-based transport (MCP spec 2024-11-05).
+	// Requires a persistent GET SSE connection before POSTing messages, which means
+	// load balancers must route both requests to the same pod (session affinity needed).
+	TransportTypeSSE TransportType = "sse"
+
+	// TransportTypeStreamableHTTP uses the modern Streamable HTTP transport (MCP spec 2025-03-26).
+	// Each POST is handled independently and the JSON-RPC response is returned directly
+	// in the HTTP body. No persistent connection or pod affinity is required, making this
+	// the recommended choice for horizontally-scaled deployments.
+	TransportTypeStreamableHTTP TransportType = "streamable-http"
+)
+
 // Config represents the configuration options for GinMCP
 type Config struct {
 	Name              string
@@ -56,9 +72,20 @@ type Config struct {
 	ExcludeTags       []string
 	// ForwardAuthHeaders enables forwarding of Authorization headers from MCP requests
 	// to internal tool execution HTTP calls. When enabled, the Authorization header from
-	// the SSE connection is captured and included in requests to tool endpoints.
+	// the connection is captured and included in requests to tool endpoints.
 	// Default: false (for backward compatibility)
 	ForwardAuthHeaders bool
+	// TransportType selects the MCP transport protocol.
+	// Default: TransportTypeSSE (for backward compatibility).
+	// Use TransportTypeStreamableHTTP for horizontally-scaled deployments.
+	TransportType TransportType
+	// AllowedOrigins is an optional list of permitted Origin header values for
+	// Streamable HTTP connections (e.g. ["https://app.example.com"]).
+	// When non-empty, requests carrying an Origin header not in this list are rejected
+	// with 403 Forbidden, preventing DNS rebinding attacks (MCP spec 2025-03-26 §Security).
+	// Server-to-server requests without an Origin header are always allowed.
+	// Default: nil (all origins permitted — rely on authentication for access control).
+	AllowedOrigins []string
 }
 
 // New creates a new GinMCP instance
@@ -163,7 +190,11 @@ func (m *GinMCP) Mount(mountPath string) {
 	}
 
 	// 2. Create transport and register handlers
-	m.transport = transport.NewSSETransport(mountPath)
+	if m.config.TransportType == TransportTypeStreamableHTTP {
+		m.transport = transport.NewStreamableHTTPTransport(mountPath, m.config.AllowedOrigins)
+	} else {
+		m.transport = transport.NewSSETransport(mountPath)
+	}
 	m.transport.RegisterHandler("initialize", m.handleInitialize)
 	m.transport.RegisterHandler("tools/list", m.handleToolsList)
 	m.transport.RegisterHandler("tools/call", m.handleToolCall)
@@ -263,12 +294,18 @@ func (m *GinMCP) handleInitialize(msg *types.MCPMessage) *types.MCPMessage {
 		log.Printf("Received initialize request with params: %+v", params)
 	}
 
-	// Return server capabilities with correct structure
+	// Return server capabilities with correct structure.
+	// Protocol version matches the transport: Streamable HTTP uses 2025-03-26, SSE uses 2024-11-05.
+	protocolVersion := "2024-11-05"
+	if m.config.TransportType == TransportTypeStreamableHTTP {
+		protocolVersion = "2025-03-26"
+	}
+
 	return &types.MCPMessage{
 		Jsonrpc: "2.0",
 		ID:      msg.ID,
 		Result: map[string]interface{}{
-			"protocolVersion": "2024-11-05",
+			"protocolVersion": protocolVersion,
 			"capabilities": map[string]interface{}{
 				"tools": map[string]interface{}{
 					"enabled": true,

--- a/server.go
+++ b/server.go
@@ -54,6 +54,11 @@ type Config struct {
 	ExcludeOperations []string
 	IncludeTags       []string
 	ExcludeTags       []string
+	// ForwardAuthHeaders enables forwarding of Authorization headers from MCP requests
+	// to internal tool execution HTTP calls. When enabled, the Authorization header from
+	// the SSE connection is captured and included in requests to tool endpoints.
+	// Default: false (for backward compatibility)
+	ForwardAuthHeaders bool
 }
 
 // New creates a new GinMCP instance
@@ -332,6 +337,16 @@ func (m *GinMCP) handleToolCall(msg *types.MCPMessage) *types.MCPMessage {
 		}
 	}
 
+	// Extract connection ID from params (injected by transport layer)
+	var connID string
+	if connIDVal, exists := reqParams["_mcpConnectionID"]; exists {
+		if connIDStr, ok := connIDVal.(string); ok {
+			connID = connIDStr
+			// Remove it from params so it doesn't get passed to tool execution
+			delete(reqParams, "_mcpConnectionID")
+		}
+	}
+
 	// Get tool name and arguments from the params
 	toolName, nameOk := reqParams["name"].(string)
 	// The actual arguments passed by the LLM are nested under "arguments"
@@ -341,6 +356,14 @@ func (m *GinMCP) handleToolCall(msg *types.MCPMessage) *types.MCPMessage {
 			Jsonrpc: "2.0", ID: msg.ID,
 			Error: map[string]interface{}{"code": -32602, "message": "Missing tool name or arguments"},
 		}
+	}
+
+	// Inject connection ID into toolArgs for auth forwarding (if enabled)
+	if connID != "" && m.config.ForwardAuthHeaders {
+		if toolArgs == nil {
+			toolArgs = make(map[string]interface{})
+		}
+		toolArgs["_mcpConnectionID"] = connID
 	}
 
 	// *** Add check for tool existence BEFORE executing ***
@@ -633,6 +656,22 @@ func (m *GinMCP) defaultExecuteTool(operationID string, parameters map[string]in
 // with different baseURL resolution strategies
 func (m *GinMCP) executeToolLogic(operation types.Operation, parameters map[string]interface{}, baseURL string) (interface{}, error) {
 
+	// Extract connection ID for auth forwarding (if present)
+	var authHeader string
+	if m.config.ForwardAuthHeaders {
+		if connIDVal, exists := parameters["_mcpConnectionID"]; exists {
+			if connID, ok := connIDVal.(string); ok && connID != "" {
+				// Get auth header from transport
+				authHeader = m.transport.GetAuthHeader(connID)
+				if isDebugMode() && authHeader != "" {
+					log.Printf("[Tool Execution] Forwarding auth header for connection %s", connID)
+				}
+			}
+			// Remove connection ID from parameters
+			delete(parameters, "_mcpConnectionID")
+		}
+	}
+
 	path := operation.Path
 	queryParams := url.Values{}
 	pathParams := make(map[string]string)
@@ -713,6 +752,14 @@ func (m *GinMCP) executeToolLogic(operation types.Operation, parameters map[stri
 	req.Header.Set("Accept", "application/json")
 	if reqBody != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Forward Authorization header if available
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+		if isDebugMode() {
+			log.Printf("[Tool Execution] Forwarding Authorization header")
+		}
 	}
 
 	if isDebugMode() {

--- a/server_test.go
+++ b/server_test.go
@@ -26,6 +26,8 @@ type mockTransport struct {
 	MockExecuteError  error
 	LastExecuteTool   *types.Tool
 	LastExecuteArgs   map[string]interface{}
+	// MockAuthHeader is returned by GetAuthHeader for testing ForwardAuthHeaders behaviour.
+	MockAuthHeader string
 }
 
 func newMockTransport() *mockTransport {
@@ -65,6 +67,8 @@ func (m *mockTransport) RemoveConnection(connID string) {
 }
 
 func (m *mockTransport) NotifyToolsChanged() { m.NotifiedToolsChanged = true }
+
+func (m *mockTransport) GetAuthHeader(connID string) string { return m.MockAuthHeader }
 
 // Mock executeTool behavior for handleToolCall tests
 func (m *mockTransport) executeTool(tool *types.Tool, args map[string]interface{}) interface{} {
@@ -475,6 +479,34 @@ func TestHandleInitialize_InvalidParams(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, -32602, errMap["code"].(int))
 	assert.Contains(t, errMap["message"].(string), "Invalid parameters format")
+}
+
+func TestHandleInitialize_StreamableHTTP(t *testing.T) {
+	mcp := New(gin.New(), &Config{
+		Name:          "MyServer",
+		TransportType: TransportTypeStreamableHTTP,
+	})
+	req := &types.MCPMessage{
+		Jsonrpc: "2.0",
+		ID:      types.RawMessage(`"init-sh-1"`),
+		Method:  "initialize",
+		Params:  map[string]interface{}{"clientInfo": "testClient"},
+	}
+
+	resp := mcp.handleInitialize(req)
+	assert.NotNil(t, resp)
+	assert.Equal(t, req.ID, resp.ID)
+	assert.Nil(t, resp.Error)
+	assert.NotNil(t, resp.Result)
+
+	resultMap, ok := resp.Result.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "2025-03-26", resultMap["protocolVersion"],
+		"Streamable HTTP transport must advertise protocol version 2025-03-26")
+	assert.Contains(t, resultMap, "capabilities")
+	serverInfo, ok := resultMap["serverInfo"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "MyServer", serverInfo["name"])
 }
 
 func TestHandleToolsList(t *testing.T) {
@@ -928,6 +960,84 @@ func GetProduct(c *gin.Context) {
 // @return Created product information
 func CreateProduct(c *gin.Context) {
 	c.JSON(200, gin.H{"message": "create product"})
+}
+
+func TestHandleToolCall_ForwardAuthHeaders(t *testing.T) {
+	dummyTool := types.Tool{
+		Name:        "do_something",
+		Description: "Does something",
+		InputSchema: &types.JSONSchema{
+			Type: "object",
+			Properties: map[string]*types.JSONSchema{
+				"param1": {Type: "string"},
+			},
+		},
+	}
+
+	// makeReq builds a tools/call message that includes _mcpConnectionID at the top level,
+	// as the transport layer injects it before passing the message to the handler.
+	makeReq := func(connID string) *types.MCPMessage {
+		return &types.MCPMessage{
+			Jsonrpc: "2.0",
+			ID:      types.RawMessage(`"fw-1"`),
+			Method:  "tools/call",
+			Params: map[string]interface{}{
+				"name":              dummyTool.Name,
+				"_mcpConnectionID":  connID,
+				"arguments":         map[string]interface{}{"param1": "v1"},
+			},
+		}
+	}
+
+	t.Run("Enabled_InjectsConnIDIntoToolArgs", func(t *testing.T) {
+		engine := gin.New()
+		mockT := newMockTransport()
+		mockT.MockAuthHeader = "Bearer secret-token"
+
+		mcp := New(engine, &Config{ForwardAuthHeaders: true})
+		mcp.transport = mockT
+		mcp.tools = []types.Tool{dummyTool}
+		mcp.operations[dummyTool.Name] = types.Operation{Method: "GET", Path: "/do"}
+
+		var capturedArgs map[string]interface{}
+		mcp.executeToolFunc = func(_ string, params map[string]interface{}) (interface{}, error) {
+			capturedArgs = params
+			return "ok", nil
+		}
+
+		resp := mcp.handleToolCall(makeReq("conn-abc"))
+		assert.Nil(t, resp.Error)
+		// _mcpConnectionID must be forwarded into toolArgs so that executeToolLogic
+		// can retrieve the auth header from the transport.
+		assert.Equal(t, "conn-abc", capturedArgs["_mcpConnectionID"],
+			"_mcpConnectionID should be in toolArgs when ForwardAuthHeaders is enabled")
+		// Regular args must still be present and unaffected.
+		assert.Equal(t, "v1", capturedArgs["param1"])
+	})
+
+	t.Run("Disabled_DoesNotInjectConnID", func(t *testing.T) {
+		engine := gin.New()
+		mockT := newMockTransport()
+
+		mcp := New(engine, &Config{ForwardAuthHeaders: false})
+		mcp.transport = mockT
+		mcp.tools = []types.Tool{dummyTool}
+		mcp.operations[dummyTool.Name] = types.Operation{Method: "GET", Path: "/do"}
+
+		var capturedArgs map[string]interface{}
+		mcp.executeToolFunc = func(_ string, params map[string]interface{}) (interface{}, error) {
+			capturedArgs = params
+			return "ok", nil
+		}
+
+		resp := mcp.handleToolCall(makeReq("conn-xyz"))
+		assert.Nil(t, resp.Error)
+		// _mcpConnectionID must NOT reach executeToolFunc when forwarding is disabled.
+		assert.NotContains(t, capturedArgs, "_mcpConnectionID",
+			"_mcpConnectionID should NOT be in toolArgs when ForwardAuthHeaders is disabled")
+		// Regular args must still be present and unaffected.
+		assert.Equal(t, "v1", capturedArgs["param1"])
+	})
 }
 
 // --- Handlers for tag filtering tests ---


### PR DESCRIPTION
## Summary

This PR adds two new features to gin-mcp:

1. **Streamable HTTP transport** — implements the modern MCP spec 2025-03-26, making gin-mcp viable for horizontally-scaled deployments without session affinity.
2. **Authorization header forwarding** — enables gin-mcp to work with authenticated APIs by forwarding the client's `Authorization` header to internal tool execution HTTP calls.

Both features are fully backward compatible: all existing SSE-based integrations continue to work without any configuration changes.

---

## 1. Streamable HTTP Transport (MCP spec 2025-03-26)

### Motivation

The original SSE transport (MCP spec 2024-11-05) requires a persistent GET connection and a POST connection to be routed to the **same pod**. This forces load balancers to use session affinity (sticky sessions), which conflicts with horizontal autoscaling and is unsupported by many managed load balancers (e.g. GCP, AWS ALB in default mode).

The MCP specification 2025-03-26 introduces **Streamable HTTP** transport to address exactly this problem: every POST request is handled independently and the JSON-RPC response is returned directly in the HTTP response body. No persistent connection or pod affinity is required.

### What changed

**`pkg/transport/streamable_http.go`** *(new file)*

A new `StreamableHTTPTransport` that implements the `Transport` interface:

- **POST `/mcp`**: Handles JSON-RPC requests. Response returned synchronously in the HTTP body (`application/json`).
- **GET `/mcp`** *(optional)*: Provides a persistent SSE channel for server-initiated notifications (e.g. `notifications/tools/listChanged`). Clients that need push events can open an SSE session via `Mcp-Session-Id` header. Not required for basic request-response.
- **202 Accepted for notifications**: Per spec, JSON-RPC notifications and responses (messages with no `id`) return `202 Accepted` with no body — no JSON-RPC reply is generated.
- **Origin validation** (DNS rebinding protection): Requests carrying an `Origin` header are validated against a configurable `AllowedOrigins` allowlist. Absent `Origin` (server-to-server calls) is always permitted.
- **CORS**: `Access-Control-Allow-Origin` echoes back the validated request origin rather than broadcasting `*` when an allowlist is configured.
- **Auth header forwarding**: Captures the `Authorization` header per-request (using a UUID injected as `_mcpConnectionID`) and exposes it via `GetAuthHeader()` for tool execution.

**`server.go`**

- New `TransportType` string type with two constants:
  - `TransportTypeSSE` — original SSE transport (default, backward compatible)
  - `TransportTypeStreamableHTTP` — new Streamable HTTP transport
- New `AllowedOrigins []string` field in `Config` — optional Origin header allowlist for Streamable HTTP (see security notes below).
- `Mount()` now selects the transport based on `Config.TransportType`.
- `handleInitialize()` returns `protocolVersion: "2025-03-26"` for Streamable HTTP and `"2024-11-05"` for SSE, matching the spec.

### Usage

```go
mcp := ginmcp.New(router, &ginmcp.Config{
    Name:          "My API",
    BaseURL:       "https://api.example.com",
    TransportType: ginmcp.TransportTypeStreamableHTTP,
    // Optional: restrict to specific browser origins (DNS rebinding protection)
    // AllowedOrigins: []string{"https://app.example.com"},
})
mcp.Mount("/mcp")
```

MCP clients connect with a single POST to `/mcp` — no prior GET connection needed.

### Security: DNS rebinding protection

Per [MCP spec 2025-03-26 §Security](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#security-considerations), servers **MUST** validate the `Origin` header to prevent DNS rebinding attacks.

- When `AllowedOrigins` is non-empty: requests with an `Origin` header not in the list are rejected with `403 Forbidden`.
- When `AllowedOrigins` is empty (default): all origins are permitted. This is appropriate when the server is already protected by authentication (e.g. Bearer token), which prevents browsers from making unauthorised requests even without Origin validation.
- Requests without an `Origin` header (server-to-server calls, `curl`, etc.) are always permitted.

---

## 2. Authorization Header Forwarding

### Motivation

Many REST APIs protected by JWT Bearer tokens validate the token in each handler. When gin-mcp executes a tool by making an internal HTTP call to a Gin route, it previously had no way to pass the client's `Authorization` header along — so tool calls would fail authentication.

### What changed

**`pkg/transport/sse.go`**

- New `ConnectionContext` struct: holds the message channel + the `Authorization` header captured at SSE connection time.
- `AddConnection(connID string, connCtx *ConnectionContext)` — signature updated to accept the full context (previously accepted `chan *types.MCPMessage` directly).
- `GetAuthHeader(connID string) string` — retrieves the auth header for a connection.
- `HandleConnection` captures `c.Request.Header.Get("Authorization")` and stores it in the `ConnectionContext`.

**`pkg/transport/transport.go`**

- `GetAuthHeader(connID string) string` added to the `Transport` interface.
- Implemented by both `SSETransport` and `StreamableHTTPTransport`.

**`server.go`**

- New `ForwardAuthHeaders bool` field in `Config` (default: `false`).
- When enabled, `HandleMessage` / tool execution injects `_mcpConnectionID` into the request params. `executeToolLogic` uses this ID to retrieve the auth header via `transport.GetAuthHeader()` and sets it on the outbound HTTP request.

### Usage

```go
mcp := ginmcp.New(router, &ginmcp.Config{
    Name:               "My API",
    BaseURL:            "https://api.example.com",
    ForwardAuthHeaders: true,
})
mcp.Mount("/mcp")
```

The client authenticates once (via the SSE connection for SSE transport, or per-POST for Streamable HTTP), and gin-mcp automatically forwards the `Authorization` header to every tool execution call.

---

## Test changes

### Existing test updates

- **`pkg/transport/sse_test.go`**: Updated all `AddConnection` call sites to pass `*ConnectionContext` instead of `chan *types.MCPMessage` directly (required by the updated `AddConnection` signature).
- **`server_test.go`**: Extended to cover the two new server-level behaviours introduced by this PR:
  - `mockTransport.MockAuthHeader` field added so `GetAuthHeader` returns a configurable value (previously always `""`).
  - `TestHandleInitialize_StreamableHTTP` — verifies that `handleInitialize` returns `protocolVersion: "2025-03-26"` when `TransportType == TransportTypeStreamableHTTP`. The existing `TestHandleInitialize` only covered the SSE (`"2024-11-05"`) branch.
  - `TestHandleToolCall_ForwardAuthHeaders` (two sub-tests):
    - `Enabled_InjectsConnIDIntoToolArgs` — when `ForwardAuthHeaders: true`, the `_mcpConnectionID` extracted from the top-level params is re-injected into `toolArgs` so `executeToolLogic` can retrieve the auth header from the transport.
    - `Disabled_DoesNotInjectConnID` — when `ForwardAuthHeaders: false`, `_mcpConnectionID` does not reach `executeToolFunc`.

All existing tests pass (`go test -race ./...`). The SSE transport behaviour is unchanged.

### New: `pkg/transport/streamable_http_test.go`

A dedicated whitebox test suite for `StreamableHTTPTransport`, mirroring the structure and depth of `sse_test.go`. 32 tests covering:

**Constructor**
- `TestNewStreamableHTTPTransport` — all internal maps initialised, no allowedOrigins by default.
- `TestNewStreamableHTTPTransport_WithAllowedOrigins` — allowlist stored correctly.

**Handler registration**
- `TestStreamableHTTPTransport_RegisterHandler` — register, verify in map, overwrite.

**Origin helpers (unit tests)**
- `TestStreamableHTTPTransport_IsOriginAllowed` (7 sub-cases) — empty origin always permitted; no allowlist permits all; allowlist match/miss; multi-origin list.
- `TestStreamableHTTPTransport_CorsOriginHeader` (4 sub-cases) — echoes origin when allowlist is configured; falls back to `*` otherwise.

**`isNotification` helper**
- `TestIsNotification` — `nil` ID, `null` ID, string ID, numeric ID.

**`HandleMessage`**
- `TestStreamableHTTPTransport_HandleMessage_Success` — handler called, response in HTTP body (not SSE channel).
- `TestStreamableHTTPTransport_HandleMessage_Notification` — no-ID message → `202 Accepted`, empty body, handler not invoked.
- `TestStreamableHTTPTransport_HandleMessage_NullID` — explicit `"id":null` → `202 Accepted`.
- `TestStreamableHTTPTransport_HandleMessage_BadRequestBody` — invalid JSON → `400`.
- `TestStreamableHTTPTransport_HandleMessage_HandlerNotFound` — unknown method → `200` with JSON-RPC `-32601` error directly in body.
- `TestStreamableHTTPTransport_HandleMessage_DisallowedOrigin` — `Origin` not in allowlist → `403`.
- `TestStreamableHTTPTransport_HandleMessage_AllowedOriginPermitted` — `Origin` in allowlist → `200`.
- `TestStreamableHTTPTransport_HandleMessage_NoOriginAlwaysPermitted` — no `Origin` header (server-to-server) → always allowed even when allowlist is set.
- `TestStreamableHTTPTransport_HandleMessage_CORSWildcardWhenNoAllowlist` — documents that `HandleMessage` does not set `Access-Control-Allow-Origin` (delegates to router middleware).
- `TestStreamableHTTPTransport_HandleMessage_ResponseDirectlyInBody` — asserts the key architectural difference: response is synchronous in the HTTP body with no SSE session created.

**Auth header forwarding**
- `TestStreamableHTTPTransport_GetAuthHeader` — `Authorization` header captured during request, retrievable via `GetAuthHeader()` inside the handler, cleaned up after request returns.
- `TestStreamableHTTPTransport_GetAuthHeader_MissingToken` — unknown request ID → empty string.
- `TestStreamableHTTPTransport_MCPConnectionID_InjectedIntoParams` — `_mcpConnectionID` UUID injected alongside existing params.
- `TestStreamableHTTPTransport_MCPConnectionID_InjectedWhenParamsNil` — `_mcpConnectionID` injected even when the request has no `params` field.

**`HandleConnection` (optional SSE push channel)**
- `TestStreamableHTTPTransport_HandleConnection_MissingSessionID` — missing `Mcp-Session-Id` header → `400`.
- `TestStreamableHTTPTransport_HandleConnection_DisallowedOrigin` — blocked origin on GET → `403`.
- `TestStreamableHTTPTransport_HandleConnection_SSEHeaders` — correct SSE headers set; session registered in map; session cleaned up on disconnect.
- `TestStreamableHTTPTransport_HandleConnection_SendsMessage` — message pushed to the session channel appears in the SSE response body.
- `TestStreamableHTTPTransport_HandleConnection_DuplicateSessionID` — documents the **behavioural difference from SSE**: reconnecting with the same `Mcp-Session-Id` silently overwrites the map entry without closing the old channel (SSE explicitly closes and removes the old connection first).
- `TestStreamableHTTPTransport_HandleConnection_CORSWithAllowedOrigin` — `Access-Control-Allow-Origin` echoes the validated origin for SSE GET connections.

**`NotifyToolsChanged`**
- `TestStreamableHTTPTransport_NotifyToolsChanged` — both registered SSE sessions receive `notifications/tools/listChanged` with correct `jsonrpc` and `method`.
- `TestStreamableHTTPTransport_NotifyToolsChanged_NoSessions` — no panic when no sessions are open.

**Concurrency**
- `TestStreamableHTTPTransport_ConcurrentHandleMessage` — 20 concurrent POST requests; no data races on `requestAuths`; all entries cleaned up after completion.
- `TestStreamableHTTPTransport_ConcurrentRegisterHandler` — 10 concurrent `RegisterHandler` calls; no races on `handlers` map.

**Stateless behaviour**
- `TestStreamableHTTPTransport_StatelessRequests` — three independent POSTs with no prior GET; no SSE sessions or `requestAuths` entries accumulate.

**Interface compliance**
- `TestStreamableHTTPTransport_ImplementsTransportInterface` — compile-time `var _ Transport = (*StreamableHTTPTransport)(nil)`.

---

## Documentation

**`README.md`** updated with two new sections:

- **Streamable HTTP Transport** — explains the motivation (session affinity problem), shows a minimal `TransportType: TransportTypeStreamableHTTP` snippet, and documents the `AllowedOrigins` DNS-rebinding protection with clear rules for when to use it.
- **Authorization Header Forwarding** — shows the `ForwardAuthHeaders: true` snippet, clarifies the SSE-vs-Streamable-HTTP capture semantics, and documents the default-off behaviour.

The Features list is also extended with bullet points for both new capabilities.

---

## Backward compatibility

| Scenario | Impact |
|---|---|
| Existing SSE config (no `TransportType` set) | ✅ No change — SSE is the default |
| Existing SSE config (no `ForwardAuthHeaders`) | ✅ No change — disabled by default |
| Existing SSE config (no `AllowedOrigins`) | ✅ No change — all origins permitted |
| Custom `Transport` implementations | ⚠️ Must add `GetAuthHeader(connID string) string` method |

### Breaking change details

`GetAuthHeader(connID string) string` was added to the exported `transport.Transport` interface. Any code that explicitly implements this interface must add this method.

**Practical impact is very limited.** The `transport` field in `GinMCP` is **unexported**, which means external callers cannot inject a custom `Transport` implementation into gin-mcp at runtime — there is no setter and no exported constructor that accepts one. The interface is exported for structural typing, but the only code in the wild that would implement it are:

1. **Internal whitebox tests** — e.g. a fork or embedded copy of gin-mcp that mocks `Transport` the same way `server_test.go` does. Fix: add `func (m *myMock) GetAuthHeader(_ string) string { return "" }`.
2. **Code that stores a value of type `transport.Transport`** (e.g. `var t transport.Transport = myImpl{}`). Fix: implement the new method.

If you are only using gin-mcp as a library (calling `ginmcp.New` and `mcp.Mount`) and have not implemented the `Transport` interface yourself, **this change does not affect you**.