### PR TITLE
fix: handle logging/setLevel and remove non-standard capability

### DIFF
--- a/server.go
+++ b/server.go
@@ -198,6 +198,7 @@ func (m *GinMCP) Mount(mountPath string) {
 	m.transport.RegisterHandler("initialize", m.handleInitialize)
 	m.transport.RegisterHandler("tools/list", m.handleToolsList)
 	m.transport.RegisterHandler("tools/call", m.handleToolCall)
+	m.transport.RegisterHandler("logging/setLevel", m.handleLoggingSetLevel)
 
 	// 3. Setup CORS middleware
 	m.engine.Use(func(c *gin.Context) {
@@ -319,9 +320,6 @@ func (m *GinMCP) handleInitialize(msg *types.MCPMessage) *types.MCPMessage {
 				"resources": map[string]interface{}{
 					"enabled": true,
 				},
-				"logging": map[string]interface{}{
-					"enabled": false,
-				},
 				"roots": map[string]interface{}{
 					"listChanged": false,
 				},
@@ -360,6 +358,17 @@ func (m *GinMCP) handleToolsList(msg *types.MCPMessage) *types.MCPMessage {
 				"count":   len(m.tools),
 			},
 		},
+	}
+}
+
+// handleLoggingSetLevel handles the logging/setLevel request.
+// gin-mcp does not implement log streaming, so this is a no-op that satisfies
+// MCP clients (e.g. Claude Inspector) that send this method on startup.
+func (m *GinMCP) handleLoggingSetLevel(msg *types.MCPMessage) *types.MCPMessage {
+	return &types.MCPMessage{
+		Jsonrpc: "2.0",
+		ID:      msg.ID,
+		Result:  map[string]interface{}{},
 	}
 }
 
@@ -878,7 +887,7 @@ func NewHeaderResolver(headerName string, fallback string) BaseURLResolver {
 		// 1. Thread-local storage
 		// 2. Context.Context passed through the call chain
 		// 3. Middleware that sets a global variable
-		
+
 		// For now, return fallback - see example usage for complete implementation
 		return fallback
 	}
@@ -901,7 +910,7 @@ func NewQuicknodeResolver(fallback string) BaseURLResolver {
 			}
 			return host
 		}
-		
+
 		return fallback
 	}
 }
@@ -917,7 +926,7 @@ func NewRAGFlowResolver(fallback string) BaseURLResolver {
 		if workflowURL := os.Getenv("RAGFLOW_WORKFLOW_URL"); workflowURL != "" {
 			return workflowURL
 		}
-		
+
 		// Try building from base URL and workflow ID
 		baseURL := os.Getenv("RAGFLOW_BASE_URL")
 		workflowID := os.Getenv("WORKFLOW_ID")
@@ -925,12 +934,12 @@ func NewRAGFlowResolver(fallback string) BaseURLResolver {
 			baseURL = strings.TrimSuffix(baseURL, "/")
 			return baseURL + "/workflow/" + workflowID
 		}
-		
+
 		// Try just base URL
 		if baseURL != "" {
 			return baseURL
 		}
-		
+
 		// Try generic HOST variable
 		if host := os.Getenv("HOST"); host != "" {
 			if !strings.HasPrefix(host, "http") {
@@ -938,7 +947,7 @@ func NewRAGFlowResolver(fallback string) BaseURLResolver {
 			}
 			return host
 		}
-		
+
 		return fallback
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -437,6 +437,42 @@ func toolExists(tools []types.Tool, name string) bool {
 	return false
 }
 
+func TestHandleLoggingSetLevel(t *testing.T) {
+	mcp := New(gin.New(), nil)
+	req := &types.MCPMessage{
+		Jsonrpc: "2.0",
+		ID:      types.RawMessage(`"log-1"`),
+		Method:  "logging/setLevel",
+		Params:  map[string]interface{}{"level": "debug"},
+	}
+
+	resp := mcp.handleLoggingSetLevel(req)
+	assert.NotNil(t, resp)
+	assert.Equal(t, req.ID, resp.ID)
+	assert.Nil(t, resp.Error)
+	resultMap, ok := resp.Result.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Empty(t, resultMap)
+}
+
+func TestHandleLoggingSetLevel_InvalidLevel(t *testing.T) {
+	mcp := New(gin.New(), nil)
+	req := &types.MCPMessage{
+		Jsonrpc: "2.0",
+		ID:      types.RawMessage(`"log-2"`),
+		Method:  "logging/setLevel",
+		Params:  map[string]interface{}{"level": "trace"},
+	}
+
+	resp := mcp.handleLoggingSetLevel(req)
+	assert.NotNil(t, resp)
+	assert.Equal(t, req.ID, resp.ID)
+	assert.Nil(t, resp.Error)
+	resultMap, ok := resp.Result.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Empty(t, resultMap)
+}
+
 func TestHandleInitialize(t *testing.T) {
 	mcp := New(gin.New(), &Config{Name: "MyServer"})
 	req := &types.MCPMessage{
@@ -982,9 +1018,9 @@ func TestHandleToolCall_ForwardAuthHeaders(t *testing.T) {
 			ID:      types.RawMessage(`"fw-1"`),
 			Method:  "tools/call",
 			Params: map[string]interface{}{
-				"name":              dummyTool.Name,
-				"_mcpConnectionID":  connID,
-				"arguments":         map[string]interface{}{"param1": "v1"},
+				"name":             dummyTool.Name,
+				"_mcpConnectionID": connID,
+				"arguments":        map[string]interface{}{"param1": "v1"},
 			},
 		}
 	}


### PR DESCRIPTION
## Summary

Improves MCP Inspector compatibility by aligning the `logging` capability with MCP spec and adding a no-op handler for `logging/setLevel`.

## Background

When connecting gin-mcp to MCP Inspector, the client sends a `logging/setLevel` request that currently isn't handled, which can  surface as an error on the client side.

Looking into it, there seem to be two small things we could improve:

1. The initialize response currently includes:
```go
   "logging": map[string]interface{}{
       "enabled": false,
   },
```
   The MCP spec defines the capability shape as `{"logging": {}}`,  and the `enabled` field isn't part of the spec — standard clients ignore unknown fields, so the presence of the `logging` key alone signals support. Since gin-mcp doesn't emit `notifications/message`(it auto-maps Gin routes to tools), it might be cleaner to omit the capability entirely. Per spec, only servers that emit log notifications need to declare it.

2. Some clients (MCP Inspector being one) send `logging/setLevel` regardless of capability declaration. A tiny no-op handler would let gin-mcp tolerate this gracefully.

## Changes

- Remove the `logging` capability from the initialize response so the advertised capabilities match actual server behavior.
- Add a no-op handler for `logging/setLevel` that returns an empty result. No level validation since gin-mcp doesn't act on the value.

## Testing

- Added unit tests for the new handler.
- Verified MCP Inspector connects cleanly after the change.

## Spec Reference

https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging
> Servers that emit log message notifications MUST declare the `logging` capability

## Notes

No breaking changes — the `enabled: false` field was effectively a no-op for standard clients anyway. Happy to adjust the approach if you'd prefer a different direction (e.g., keeping the capability and implementing full logging support instead).