### PR TITLE
Add context to handlers

### DIFF
--- a/examples/simple/quicknode.go
+++ b/examples/simple/quicknode.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	server "github.com/ckanthony/gin-mcp"
@@ -38,7 +39,7 @@ func configureMCPForQuicknode(r *gin.Engine) {
 	resolver := server.NewQuicknodeResolver("http://localhost:8080")
 
 	// Override the default tool execution with dynamic baseURL logic
-	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, resolver)
 	})
 
@@ -60,7 +61,7 @@ func configureMCPForQuicknodeWithCustomEnv(r *gin.Engine) {
 
 	// Use environment-specific resolver with custom variable name
 	envResolver := server.NewEnvironmentResolver("MY_QUICKNODE_ENDPOINT", "http://localhost:8080")
-	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, envResolver)
 	})
 
@@ -80,7 +81,7 @@ func configureMCPForQuicknodeDirectly(r *gin.Engine) {
 	mcp.RegisterSchema("PUT", "/products/:id", nil, UpdateProductRequest{})
 
 	// Direct approach: check environment and use dynamic URL
-	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		// Try multiple environment variables in order of preference
 		userEndpoint := os.Getenv("QUICKNODE_USER_ENDPOINT")
 		if userEndpoint == "" {

--- a/examples/simple/quicknode.go
+++ b/examples/simple/quicknode.go
@@ -11,15 +11,17 @@ import (
 // where each user has their own dynamic endpoint proxied through Quicknode.
 //
 // Usage:
-//   r := gin.Default()
-//   registerRoutes(r)
-//   configureMCPForQuicknode(r)  // Use this instead of configureMCP(r)
-//   r.Run(":8080")
+//
+//	r := gin.Default()
+//	registerRoutes(r)
+//	configureMCPForQuicknode(r)  // Use this instead of configureMCP(r)
+//	r.Run(":8080")
 //
 // Environment Variables:
-//   QUICKNODE_USER_ENDPOINT - The user's specific endpoint (e.g., "https://user1.quicknode.endpoint.com")
-//   USER_ENDPOINT           - Alternative environment variable name
-//   HOST                    - Host without protocol (will add https://)
+//
+//	QUICKNODE_USER_ENDPOINT - The user's specific endpoint (e.g., "https://user1.quicknode.endpoint.com")
+//	USER_ENDPOINT           - Alternative environment variable name
+//	HOST                    - Host without protocol (will add https://)
 func configureMCPForQuicknode(r *gin.Engine) {
 	mcp := server.New(r, &server.Config{
 		Name:        "Gaming Store API",
@@ -34,9 +36,9 @@ func configureMCPForQuicknode(r *gin.Engine) {
 
 	// Setup dynamic baseURL resolution for Quicknode
 	resolver := server.NewQuicknodeResolver("http://localhost:8080")
-	
+
 	// Override the default tool execution with dynamic baseURL logic
-	mcp.SetExecuteToolFunc(func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, resolver)
 	})
 
@@ -58,7 +60,7 @@ func configureMCPForQuicknodeWithCustomEnv(r *gin.Engine) {
 
 	// Use environment-specific resolver with custom variable name
 	envResolver := server.NewEnvironmentResolver("MY_QUICKNODE_ENDPOINT", "http://localhost:8080")
-	mcp.SetExecuteToolFunc(func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, envResolver)
 	})
 
@@ -78,7 +80,7 @@ func configureMCPForQuicknodeDirectly(r *gin.Engine) {
 	mcp.RegisterSchema("PUT", "/products/:id", nil, UpdateProductRequest{})
 
 	// Direct approach: check environment and use dynamic URL
-	mcp.SetExecuteToolFunc(func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		// Try multiple environment variables in order of preference
 		userEndpoint := os.Getenv("QUICKNODE_USER_ENDPOINT")
 		if userEndpoint == "" {
@@ -93,7 +95,7 @@ func configureMCPForQuicknodeDirectly(r *gin.Engine) {
 		if userEndpoint == "" {
 			userEndpoint = "http://localhost:8080" // fallback
 		}
-		
+
 		return mcp.ExecuteToolWithDynamicURL(operationID, parameters, userEndpoint)
 	})
 

--- a/examples/simple/ragflow.go
+++ b/examples/simple/ragflow.go
@@ -40,7 +40,7 @@ func configureMCPForRAGFlow(r *gin.Engine) {
 	resolver := server.NewRAGFlowResolver("http://localhost:8080")
 
 	// Override the default tool execution with dynamic baseURL logic
-	mcp.SetExecuteToolFunc(func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, resolver)
 	})
 
@@ -62,7 +62,7 @@ func configureMCPForRAGFlowWithWorkflow(r *gin.Engine) {
 
 	// Use environment-specific resolver for workflow URLs
 	workflowResolver := server.NewEnvironmentResolver("RAGFLOW_WORKFLOW_URL", "http://localhost:8080")
-	mcp.SetExecuteToolFunc(func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, workflowResolver)
 	})
 
@@ -82,7 +82,7 @@ func configureMCPForRAGFlowDirectly(r *gin.Engine) {
 	mcp.RegisterSchema("PUT", "/products/:id", nil, UpdateProductRequest{})
 
 	// Direct approach: construct RAGFlow URL from components
-	mcp.SetExecuteToolFunc(func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		endpoint := buildRAGFlowEndpoint()
 		return mcp.ExecuteToolWithDynamicURL(operationID, parameters, endpoint)
 	})

--- a/examples/simple/ragflow.go
+++ b/examples/simple/ragflow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -40,7 +41,7 @@ func configureMCPForRAGFlow(r *gin.Engine) {
 	resolver := server.NewRAGFlowResolver("http://localhost:8080")
 
 	// Override the default tool execution with dynamic baseURL logic
-	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, resolver)
 	})
 
@@ -62,7 +63,7 @@ func configureMCPForRAGFlowWithWorkflow(r *gin.Engine) {
 
 	// Use environment-specific resolver for workflow URLs
 	workflowResolver := server.NewEnvironmentResolver("RAGFLOW_WORKFLOW_URL", "http://localhost:8080")
-	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		return mcp.ExecuteToolWithResolver(operationID, parameters, workflowResolver)
 	})
 
@@ -82,7 +83,7 @@ func configureMCPForRAGFlowDirectly(r *gin.Engine) {
 	mcp.RegisterSchema("PUT", "/products/:id", nil, UpdateProductRequest{})
 
 	// Direct approach: construct RAGFlow URL from components
-	mcp.SetExecuteToolFunc(func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.SetExecuteToolFunc(func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		endpoint := buildRAGFlowEndpoint()
 		return mcp.ExecuteToolWithDynamicURL(operationID, parameters, endpoint)
 	})

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -337,7 +337,7 @@ func (s *SSETransport) HandleMessage(c *gin.Context) {
 	}
 
 	// Execute handler and send response
-	respMsg := handler(c, &reqMsg)
+	respMsg := handler(c.Request.Context(), &reqMsg)
 	if ok := s.trySendMessage(connID, msgChan, respMsg); ok {
 		c.Status(http.StatusOK) // Changed from 204 to 200 for mcphost compatibility
 	} else {

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -337,7 +337,7 @@ func (s *SSETransport) HandleMessage(c *gin.Context) {
 	}
 
 	// Execute handler and send response
-	respMsg := handler(&reqMsg)
+	respMsg := handler(c, &reqMsg)
 	if ok := s.trySendMessage(connID, msgChan, respMsg); ok {
 		c.Status(http.StatusOK) // Changed from 204 to 200 for mcphost compatibility
 	} else {

--- a/pkg/transport/sse_test.go
+++ b/pkg/transport/sse_test.go
@@ -76,7 +76,7 @@ func TestSSETransport_MountPath(t *testing.T) {
 func TestSSETransport_RegisterHandler(t *testing.T) {
 	s := setupTestSSETransport("/mcp")
 	method := "test/method"
-	handler := func(msg *types.MCPMessage) *types.MCPMessage {
+	handler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "ok"}
 	}
 
@@ -90,7 +90,7 @@ func TestSSETransport_RegisterHandler(t *testing.T) {
 	assert.NotNil(t, registeredHandler, "Registered handler should not be nil")
 
 	// Test overwriting handler
-	newHandler := func(msg *types.MCPMessage) *types.MCPMessage {
+	newHandler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "new ok"}
 	}
 	s.RegisterHandler(method, newHandler)
@@ -99,7 +99,7 @@ func TestSSETransport_RegisterHandler(t *testing.T) {
 	s.hMu.RUnlock()
 	assert.NotNil(t, overwrittenHandler)
 	// Comparing func pointers directly is tricky; check if behavior changed
-	resp := overwrittenHandler(&types.MCPMessage{})
+	resp := overwrittenHandler(nil, &types.MCPMessage{})
 	assert.Equal(t, "new ok", resp.Result)
 }
 
@@ -302,7 +302,7 @@ func TestSSETransport_HandleMessage_Success(t *testing.T) {
 
 	method := "test/success"
 	handlerCalled := false
-	s.RegisterHandler(method, func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler(method, func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		assert.Equal(t, method, msg.Method)
 		assert.Equal(t, types.RawMessage(`"req-id-1"`), msg.ID)
@@ -339,7 +339,7 @@ func TestSSETransport_HandleMessage_NoConnectionIdHeader(t *testing.T) {
 
 	method := "test/query"
 	handlerCalled := false
-	s.RegisterHandler(method, func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler(method, func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "query success"}
 	})

--- a/pkg/transport/sse_test.go
+++ b/pkg/transport/sse_test.go
@@ -76,7 +76,7 @@ func TestSSETransport_MountPath(t *testing.T) {
 func TestSSETransport_RegisterHandler(t *testing.T) {
 	s := setupTestSSETransport("/mcp")
 	method := "test/method"
-	handler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	handler := func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "ok"}
 	}
 
@@ -90,7 +90,7 @@ func TestSSETransport_RegisterHandler(t *testing.T) {
 	assert.NotNil(t, registeredHandler, "Registered handler should not be nil")
 
 	// Test overwriting handler
-	newHandler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	newHandler := func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "new ok"}
 	}
 	s.RegisterHandler(method, newHandler)
@@ -302,7 +302,7 @@ func TestSSETransport_HandleMessage_Success(t *testing.T) {
 
 	method := "test/success"
 	handlerCalled := false
-	s.RegisterHandler(method, func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler(method, func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		assert.Equal(t, method, msg.Method)
 		assert.Equal(t, types.RawMessage(`"req-id-1"`), msg.ID)
@@ -339,7 +339,7 @@ func TestSSETransport_HandleMessage_NoConnectionIdHeader(t *testing.T) {
 
 	method := "test/query"
 	handlerCalled := false
-	s.RegisterHandler(method, func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler(method, func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "query success"}
 	})

--- a/pkg/transport/streamable_http.go
+++ b/pkg/transport/streamable_http.go
@@ -274,7 +274,7 @@ func (s *StreamableHTTPTransport) HandleMessage(c *gin.Context) {
 		return
 	}
 
-	respMsg := handler(c, &reqMsg)
+	respMsg := handler(c.Request.Context(), &reqMsg)
 	c.JSON(http.StatusOK, respMsg)
 }
 

--- a/pkg/transport/streamable_http.go
+++ b/pkg/transport/streamable_http.go
@@ -274,7 +274,7 @@ func (s *StreamableHTTPTransport) HandleMessage(c *gin.Context) {
 		return
 	}
 
-	respMsg := handler(&reqMsg)
+	respMsg := handler(c, &reqMsg)
 	c.JSON(http.StatusOK, respMsg)
 }
 

--- a/pkg/transport/streamable_http_test.go
+++ b/pkg/transport/streamable_http_test.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ckanthony/gin-mcp/pkg/types"
-	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +51,7 @@ func TestNewStreamableHTTPTransport_WithAllowedOrigins(t *testing.T) {
 func TestStreamableHTTPTransport_RegisterHandler(t *testing.T) {
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 	method := "test/method"
-	handler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	handler := func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "ok"}
 	}
 
@@ -65,7 +65,7 @@ func TestStreamableHTTPTransport_RegisterHandler(t *testing.T) {
 	assert.NotNil(t, registeredHandler)
 
 	// Test overwriting a handler
-	newHandler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	newHandler := func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "new ok"}
 	}
 	s.RegisterHandler(method, newHandler)
@@ -140,7 +140,7 @@ func TestStreamableHTTPTransport_HandleMessage_Success(t *testing.T) {
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 	method := "test/success"
 	handlerCalled := false
-	s.RegisterHandler(method, func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler(method, func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		assert.Equal(t, method, msg.Method)
 		assert.Equal(t, types.RawMessage(`"req-id-1"`), msg.ID)
@@ -163,7 +163,7 @@ func TestStreamableHTTPTransport_HandleMessage_Notification(t *testing.T) {
 	// JSON-RPC messages with no ID (notifications) must return 202 Accepted with no body.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 	handlerCalled := false
-	s.RegisterHandler("notifications/cancelled", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("notifications/cancelled", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		return nil
 	})
@@ -247,7 +247,7 @@ func TestStreamableHTTPTransport_HandleMessage_DisallowedOrigin(t *testing.T) {
 func TestStreamableHTTPTransport_HandleMessage_AllowedOriginPermitted(t *testing.T) {
 	allowedOrigin := "https://app.example.com"
 	s := setupTestStreamableHTTPTransport("/mcp", []string{allowedOrigin})
-	s.RegisterHandler("test/method", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/method", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
 
@@ -264,7 +264,7 @@ func TestStreamableHTTPTransport_HandleMessage_AllowedOriginPermitted(t *testing
 func TestStreamableHTTPTransport_HandleMessage_NoOriginAlwaysPermitted(t *testing.T) {
 	// Server-to-server calls without Origin header must always be allowed.
 	s := setupTestStreamableHTTPTransport("/mcp", []string{"https://allowed.example.com"})
-	s.RegisterHandler("test/method", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/method", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
 
@@ -285,7 +285,7 @@ func TestStreamableHTTPTransport_GetAuthHeader(t *testing.T) {
 	authValue := "Bearer test-token-xyz"
 
 	var capturedRequestID string
-	s.RegisterHandler("test/auth", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/auth", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		paramsMap, ok := msg.Params.(map[string]interface{})
 		require.True(t, ok, "Params should be a map")
 		id, ok := paramsMap["_mcpConnectionID"].(string)
@@ -321,7 +321,7 @@ func TestStreamableHTTPTransport_MCPConnectionID_InjectedIntoParams(t *testing.T
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 
 	var receivedParams map[string]interface{}
-	s.RegisterHandler("test/params", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/params", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		paramsMap, ok := msg.Params.(map[string]interface{})
 		require.True(t, ok)
 		receivedParams = paramsMap
@@ -345,7 +345,7 @@ func TestStreamableHTTPTransport_MCPConnectionID_InjectedWhenParamsNil(t *testin
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 
 	var receivedParams map[string]interface{}
-	s.RegisterHandler("test/nilparams", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/nilparams", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		paramsMap, ok := msg.Params.(map[string]interface{})
 		require.True(t, ok, "Params should be initialised as a map even when absent in request")
 		receivedParams = paramsMap
@@ -612,7 +612,7 @@ func TestStreamableHTTPTransport_NotifyToolsChanged_NoSessions(t *testing.T) {
 func TestStreamableHTTPTransport_ConcurrentHandleMessage(t *testing.T) {
 	// Verify that concurrent POST requests do not race on the requestAuths map.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
-	s.RegisterHandler("test/concurrent", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/concurrent", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		time.Sleep(5 * time.Millisecond) // simulate work
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
@@ -650,7 +650,7 @@ func TestStreamableHTTPTransport_ConcurrentRegisterHandler(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			s.RegisterHandler(fmt.Sprintf("method/%d", i), func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+			s.RegisterHandler(fmt.Sprintf("method/%d", i), func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 				return nil
 			})
 		}(i)
@@ -668,7 +668,7 @@ func TestStreamableHTTPTransport_ConcurrentRegisterHandler(t *testing.T) {
 func TestStreamableHTTPTransport_StatelessRequests(t *testing.T) {
 	// Each POST is handled independently; no prior connection needed.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
-	s.RegisterHandler("test/stateless", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/stateless", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "stateless-ok"}
 	})
 
@@ -706,7 +706,7 @@ func TestStreamableHTTPTransport_HandleMessage_CORSWildcardWhenNoAllowlist(t *te
 	// HandleMessage does not write CORS headers itself — that is the responsibility of
 	// any CORS middleware applied to the Gin router.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
-	s.RegisterHandler("test/cors", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/cors", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
 
@@ -737,7 +737,7 @@ func TestStreamableHTTPTransport_HandleMessage_ResponseDirectlyInBody(t *testing
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 
 	expectedResult := "direct-body-response"
-	s.RegisterHandler("test/direct", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/direct", func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: expectedResult}
 	})
 

--- a/pkg/transport/streamable_http_test.go
+++ b/pkg/transport/streamable_http_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +51,7 @@ func TestNewStreamableHTTPTransport_WithAllowedOrigins(t *testing.T) {
 func TestStreamableHTTPTransport_RegisterHandler(t *testing.T) {
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 	method := "test/method"
-	handler := func(msg *types.MCPMessage) *types.MCPMessage {
+	handler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "ok"}
 	}
 
@@ -64,14 +65,14 @@ func TestStreamableHTTPTransport_RegisterHandler(t *testing.T) {
 	assert.NotNil(t, registeredHandler)
 
 	// Test overwriting a handler
-	newHandler := func(msg *types.MCPMessage) *types.MCPMessage {
+	newHandler := func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Result: "new ok"}
 	}
 	s.RegisterHandler(method, newHandler)
 	s.hMu.RLock()
 	overwrittenHandler, _ := s.handlers[method]
 	s.hMu.RUnlock()
-	resp := overwrittenHandler(&types.MCPMessage{})
+	resp := overwrittenHandler(nil, &types.MCPMessage{})
 	assert.Equal(t, "new ok", resp.Result)
 }
 
@@ -139,7 +140,7 @@ func TestStreamableHTTPTransport_HandleMessage_Success(t *testing.T) {
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 	method := "test/success"
 	handlerCalled := false
-	s.RegisterHandler(method, func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler(method, func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		assert.Equal(t, method, msg.Method)
 		assert.Equal(t, types.RawMessage(`"req-id-1"`), msg.ID)
@@ -162,7 +163,7 @@ func TestStreamableHTTPTransport_HandleMessage_Notification(t *testing.T) {
 	// JSON-RPC messages with no ID (notifications) must return 202 Accepted with no body.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 	handlerCalled := false
-	s.RegisterHandler("notifications/cancelled", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("notifications/cancelled", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		handlerCalled = true
 		return nil
 	})
@@ -246,7 +247,7 @@ func TestStreamableHTTPTransport_HandleMessage_DisallowedOrigin(t *testing.T) {
 func TestStreamableHTTPTransport_HandleMessage_AllowedOriginPermitted(t *testing.T) {
 	allowedOrigin := "https://app.example.com"
 	s := setupTestStreamableHTTPTransport("/mcp", []string{allowedOrigin})
-	s.RegisterHandler("test/method", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/method", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
 
@@ -263,7 +264,7 @@ func TestStreamableHTTPTransport_HandleMessage_AllowedOriginPermitted(t *testing
 func TestStreamableHTTPTransport_HandleMessage_NoOriginAlwaysPermitted(t *testing.T) {
 	// Server-to-server calls without Origin header must always be allowed.
 	s := setupTestStreamableHTTPTransport("/mcp", []string{"https://allowed.example.com"})
-	s.RegisterHandler("test/method", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/method", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
 
@@ -284,7 +285,7 @@ func TestStreamableHTTPTransport_GetAuthHeader(t *testing.T) {
 	authValue := "Bearer test-token-xyz"
 
 	var capturedRequestID string
-	s.RegisterHandler("test/auth", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/auth", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		paramsMap, ok := msg.Params.(map[string]interface{})
 		require.True(t, ok, "Params should be a map")
 		id, ok := paramsMap["_mcpConnectionID"].(string)
@@ -320,7 +321,7 @@ func TestStreamableHTTPTransport_MCPConnectionID_InjectedIntoParams(t *testing.T
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 
 	var receivedParams map[string]interface{}
-	s.RegisterHandler("test/params", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/params", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		paramsMap, ok := msg.Params.(map[string]interface{})
 		require.True(t, ok)
 		receivedParams = paramsMap
@@ -344,7 +345,7 @@ func TestStreamableHTTPTransport_MCPConnectionID_InjectedWhenParamsNil(t *testin
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 
 	var receivedParams map[string]interface{}
-	s.RegisterHandler("test/nilparams", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/nilparams", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		paramsMap, ok := msg.Params.(map[string]interface{})
 		require.True(t, ok, "Params should be initialised as a map even when absent in request")
 		receivedParams = paramsMap
@@ -611,7 +612,7 @@ func TestStreamableHTTPTransport_NotifyToolsChanged_NoSessions(t *testing.T) {
 func TestStreamableHTTPTransport_ConcurrentHandleMessage(t *testing.T) {
 	// Verify that concurrent POST requests do not race on the requestAuths map.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
-	s.RegisterHandler("test/concurrent", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/concurrent", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		time.Sleep(5 * time.Millisecond) // simulate work
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
@@ -649,7 +650,7 @@ func TestStreamableHTTPTransport_ConcurrentRegisterHandler(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			s.RegisterHandler(fmt.Sprintf("method/%d", i), func(msg *types.MCPMessage) *types.MCPMessage {
+			s.RegisterHandler(fmt.Sprintf("method/%d", i), func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 				return nil
 			})
 		}(i)
@@ -667,7 +668,7 @@ func TestStreamableHTTPTransport_ConcurrentRegisterHandler(t *testing.T) {
 func TestStreamableHTTPTransport_StatelessRequests(t *testing.T) {
 	// Each POST is handled independently; no prior connection needed.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
-	s.RegisterHandler("test/stateless", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/stateless", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "stateless-ok"}
 	})
 
@@ -705,7 +706,7 @@ func TestStreamableHTTPTransport_HandleMessage_CORSWildcardWhenNoAllowlist(t *te
 	// HandleMessage does not write CORS headers itself — that is the responsibility of
 	// any CORS middleware applied to the Gin router.
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
-	s.RegisterHandler("test/cors", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/cors", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: "ok"}
 	})
 
@@ -736,7 +737,7 @@ func TestStreamableHTTPTransport_HandleMessage_ResponseDirectlyInBody(t *testing
 	s := setupTestStreamableHTTPTransport("/mcp", nil)
 
 	expectedResult := "direct-body-response"
-	s.RegisterHandler("test/direct", func(msg *types.MCPMessage) *types.MCPMessage {
+	s.RegisterHandler("test/direct", func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 		return &types.MCPMessage{Jsonrpc: "2.0", ID: msg.ID, Result: expectedResult}
 	})
 

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -1,12 +1,14 @@
 package transport
 
 import (
+	"context"
+
 	"github.com/ckanthony/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 )
 
 // MessageHandler defines the function signature for handling incoming MCP messages.
-type MessageHandler func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage
+type MessageHandler func(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage
 
 // Transport defines the interface for handling MCP communication over different protocols.
 type Transport interface {

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MessageHandler defines the function signature for handling incoming MCP messages.
-type MessageHandler func(msg *types.MCPMessage) *types.MCPMessage
+type MessageHandler func(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage
 
 // Transport defines the interface for handling MCP communication over different protocols.
 type Transport interface {

--- a/server.go
+++ b/server.go
@@ -42,7 +42,7 @@ type GinMCP struct {
 	schemasMu         sync.RWMutex
 	// executeToolFunc holds the function used to execute a tool.
 	// It defaults to defaultExecuteTool but can be overridden for testing.
-	executeToolFunc func(operationID string, parameters map[string]interface{}) (interface{}, error)
+	executeToolFunc func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error)
 }
 
 // TransportType selects the MCP transport protocol.
@@ -127,7 +127,7 @@ func New(engine *gin.Engine, config *Config) *GinMCP {
 
 // SetExecuteToolFunc allows overriding the default tool execution function.
 // This is useful for implementing dynamic baseURL resolution or custom execution logic.
-func (m *GinMCP) SetExecuteToolFunc(fn func(operationID string, parameters map[string]interface{}) (interface{}, error)) {
+func (m *GinMCP) SetExecuteToolFunc(fn func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error)) {
 	m.executeToolFunc = fn
 }
 
@@ -276,7 +276,7 @@ func (m *GinMCP) handleMCPConnection(c *gin.Context) {
 }
 
 // handleInitialize handles the initialize request from clients
-func (m *GinMCP) handleInitialize(msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleInitialize(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 	// Parse initialization parameters
 	params, ok := msg.Params.(map[string]interface{})
 	if !ok {
@@ -334,7 +334,7 @@ func (m *GinMCP) handleInitialize(msg *types.MCPMessage) *types.MCPMessage {
 }
 
 // handleToolsList handles the tools/list request
-func (m *GinMCP) handleToolsList(msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleToolsList(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 	// Ensure server is ready
 	if err := m.SetupServer(); err != nil {
 		return &types.MCPMessage{
@@ -364,7 +364,7 @@ func (m *GinMCP) handleToolsList(msg *types.MCPMessage) *types.MCPMessage {
 // handleLoggingSetLevel handles the logging/setLevel request.
 // gin-mcp does not implement log streaming, so this is a no-op that satisfies
 // MCP clients (e.g. Claude Inspector) that send this method on startup.
-func (m *GinMCP) handleLoggingSetLevel(msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleLoggingSetLevel(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 	return &types.MCPMessage{
 		Jsonrpc: "2.0",
 		ID:      msg.ID,
@@ -373,7 +373,7 @@ func (m *GinMCP) handleLoggingSetLevel(msg *types.MCPMessage) *types.MCPMessage 
 }
 
 // handleToolCall handles the tools/call request
-func (m *GinMCP) handleToolCall(msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleToolCall(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
 	// Parse parameters from the incoming MCP message
 	reqParams, ok := msg.Params.(map[string]interface{})
 	if !ok {
@@ -432,7 +432,7 @@ func (m *GinMCP) handleToolCall(msg *types.MCPMessage) *types.MCPMessage {
 	}
 
 	// Execute the actual Gin endpoint via internal HTTP call
-	execResult, err := m.executeToolFunc(toolName, toolArgs) // Use the function field
+	execResult, err := m.executeToolFunc(c, toolName, toolArgs) // Use the function field
 	if err != nil {
 		// Handle execution error
 		return &types.MCPMessage{
@@ -668,7 +668,7 @@ func (m *GinMCP) executeToolWithBaseURL(operationID string, parameters map[strin
 
 // defaultExecuteTool is the default implementation for executing a tool.
 // It handles the actual invocation of the underlying Gin handler using the configured baseURL.
-func (m *GinMCP) defaultExecuteTool(operationID string, parameters map[string]interface{}) (interface{}, error) {
+func (m *GinMCP) defaultExecuteTool(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 	if isDebugMode() {
 		log.Printf("[Tool Execution] Starting execution of tool '%s' with parameters: %+v", operationID, parameters)
 	}

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -42,7 +43,7 @@ type GinMCP struct {
 	schemasMu         sync.RWMutex
 	// executeToolFunc holds the function used to execute a tool.
 	// It defaults to defaultExecuteTool but can be overridden for testing.
-	executeToolFunc func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error)
+	executeToolFunc func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error)
 }
 
 // TransportType selects the MCP transport protocol.
@@ -127,7 +128,7 @@ func New(engine *gin.Engine, config *Config) *GinMCP {
 
 // SetExecuteToolFunc allows overriding the default tool execution function.
 // This is useful for implementing dynamic baseURL resolution or custom execution logic.
-func (m *GinMCP) SetExecuteToolFunc(fn func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error)) {
+func (m *GinMCP) SetExecuteToolFunc(fn func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error)) {
 	m.executeToolFunc = fn
 }
 
@@ -276,7 +277,7 @@ func (m *GinMCP) handleMCPConnection(c *gin.Context) {
 }
 
 // handleInitialize handles the initialize request from clients
-func (m *GinMCP) handleInitialize(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleInitialize(_ context.Context, msg *types.MCPMessage) *types.MCPMessage {
 	// Parse initialization parameters
 	params, ok := msg.Params.(map[string]interface{})
 	if !ok {
@@ -334,7 +335,7 @@ func (m *GinMCP) handleInitialize(c *gin.Context, msg *types.MCPMessage) *types.
 }
 
 // handleToolsList handles the tools/list request
-func (m *GinMCP) handleToolsList(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleToolsList(_ context.Context, msg *types.MCPMessage) *types.MCPMessage {
 	// Ensure server is ready
 	if err := m.SetupServer(); err != nil {
 		return &types.MCPMessage{
@@ -364,7 +365,7 @@ func (m *GinMCP) handleToolsList(c *gin.Context, msg *types.MCPMessage) *types.M
 // handleLoggingSetLevel handles the logging/setLevel request.
 // gin-mcp does not implement log streaming, so this is a no-op that satisfies
 // MCP clients (e.g. Claude Inspector) that send this method on startup.
-func (m *GinMCP) handleLoggingSetLevel(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleLoggingSetLevel(_ context.Context, msg *types.MCPMessage) *types.MCPMessage {
 	return &types.MCPMessage{
 		Jsonrpc: "2.0",
 		ID:      msg.ID,
@@ -373,7 +374,7 @@ func (m *GinMCP) handleLoggingSetLevel(c *gin.Context, msg *types.MCPMessage) *t
 }
 
 // handleToolCall handles the tools/call request
-func (m *GinMCP) handleToolCall(c *gin.Context, msg *types.MCPMessage) *types.MCPMessage {
+func (m *GinMCP) handleToolCall(ctx context.Context, msg *types.MCPMessage) *types.MCPMessage {
 	// Parse parameters from the incoming MCP message
 	reqParams, ok := msg.Params.(map[string]interface{})
 	if !ok {
@@ -432,7 +433,7 @@ func (m *GinMCP) handleToolCall(c *gin.Context, msg *types.MCPMessage) *types.MC
 	}
 
 	// Execute the actual Gin endpoint via internal HTTP call
-	execResult, err := m.executeToolFunc(c, toolName, toolArgs) // Use the function field
+	execResult, err := m.executeToolFunc(ctx, toolName, toolArgs) // Use the function field
 	if err != nil {
 		// Handle execution error
 		return &types.MCPMessage{
@@ -668,7 +669,7 @@ func (m *GinMCP) executeToolWithBaseURL(operationID string, parameters map[strin
 
 // defaultExecuteTool is the default implementation for executing a tool.
 // It handles the actual invocation of the underlying Gin handler using the configured baseURL.
-func (m *GinMCP) defaultExecuteTool(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+func (m *GinMCP) defaultExecuteTool(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 	if isDebugMode() {
 		log.Printf("[Tool Execution] Starting execution of tool '%s' with parameters: %+v", operationID, parameters)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -446,7 +446,7 @@ func TestHandleLoggingSetLevel(t *testing.T) {
 		Params:  map[string]interface{}{"level": "debug"},
 	}
 
-	resp := mcp.handleLoggingSetLevel(req)
+	resp := mcp.handleLoggingSetLevel(nil, req)
 	assert.NotNil(t, resp)
 	assert.Equal(t, req.ID, resp.ID)
 	assert.Nil(t, resp.Error)
@@ -464,7 +464,7 @@ func TestHandleLoggingSetLevel_InvalidLevel(t *testing.T) {
 		Params:  map[string]interface{}{"level": "trace"},
 	}
 
-	resp := mcp.handleLoggingSetLevel(req)
+	resp := mcp.handleLoggingSetLevel(nil, req)
 	assert.NotNil(t, resp)
 	assert.Equal(t, req.ID, resp.ID)
 	assert.Nil(t, resp.Error)
@@ -482,7 +482,7 @@ func TestHandleInitialize(t *testing.T) {
 		Params:  map[string]interface{}{"clientInfo": "testClient"},
 	}
 
-	resp := mcp.handleInitialize(req)
+	resp := mcp.handleInitialize(nil, req)
 	assert.NotNil(t, resp)
 	assert.Equal(t, req.ID, resp.ID)
 	assert.Nil(t, resp.Error)
@@ -506,7 +506,7 @@ func TestHandleInitialize_InvalidParams(t *testing.T) {
 		Params:  "not a map", // Invalid parameter type
 	}
 
-	resp := mcp.handleInitialize(req)
+	resp := mcp.handleInitialize(nil, req)
 	assert.NotNil(t, resp)
 	assert.Equal(t, req.ID, resp.ID)
 	assert.Nil(t, resp.Result)
@@ -529,7 +529,7 @@ func TestHandleInitialize_StreamableHTTP(t *testing.T) {
 		Params:  map[string]interface{}{"clientInfo": "testClient"},
 	}
 
-	resp := mcp.handleInitialize(req)
+	resp := mcp.handleInitialize(nil, req)
 	assert.NotNil(t, resp)
 	assert.Equal(t, req.ID, resp.ID)
 	assert.Nil(t, resp.Error)
@@ -559,7 +559,7 @@ func TestHandleToolsList(t *testing.T) {
 		Method:  "tools/list",
 	}
 
-	resp := mcp.handleToolsList(req)
+	resp := mcp.handleToolsList(nil, req)
 	assert.NotNil(t, resp)
 	assert.Equal(t, req.ID, resp.ID)
 	assert.Nil(t, resp.Error)
@@ -695,7 +695,7 @@ func TestHandleToolCall(t *testing.T) {
 
 	// ** Test valid tool call **
 	// Assign mock ONLY for this case
-	mcp.executeToolFunc = func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.executeToolFunc = func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		assert.Equal(t, dummyTool.Name, operationID) // operationID is the tool name here
 		assert.Equal(t, "value1", parameters["param1"])
 		return map[string]interface{}{"result": "success"}, nil // Return nil error for success
@@ -713,7 +713,7 @@ func TestHandleToolCall(t *testing.T) {
 		},
 	}
 
-	resp := mcp.handleToolCall(callReq)
+	resp := mcp.handleToolCall(nil, callReq)
 	assert.NotNil(t, resp)
 	assert.Nil(t, resp.Error, "Expected no error for valid call")
 	assert.Equal(t, callReq.ID, resp.ID)
@@ -748,7 +748,7 @@ func TestHandleToolCall(t *testing.T) {
 		Method:  "tools/call",
 		Params:  map[string]interface{}{"name": "nonexistent", "arguments": map[string]interface{}{}},
 	}
-	respNotFound := mcp.handleToolCall(callNotFound)
+	respNotFound := mcp.handleToolCall(nil, callNotFound)
 	assert.NotNil(t, respNotFound)
 	assert.NotNil(t, respNotFound.Error)
 	assert.Nil(t, respNotFound.Result)
@@ -765,7 +765,7 @@ func TestHandleToolCall(t *testing.T) {
 		Method:  "tools/call",
 		Params:  "not a map",
 	}
-	respInvalidParams := mcp.handleToolCall(callInvalidParams)
+	respInvalidParams := mcp.handleToolCall(nil, callInvalidParams)
 	assert.NotNil(t, respInvalidParams)
 	assert.NotNil(t, respInvalidParams.Error)
 	assert.Nil(t, respInvalidParams.Result)
@@ -782,7 +782,7 @@ func TestHandleToolCall(t *testing.T) {
 		Method:  "tools/call",
 		Params:  map[string]interface{}{"name": dummyTool.Name}, // Missing 'arguments'
 	}
-	respMissingArgs := mcp.handleToolCall(callMissingArgs)
+	respMissingArgs := mcp.handleToolCall(nil, callMissingArgs)
 	assert.NotNil(t, respMissingArgs)
 	assert.NotNil(t, respMissingArgs.Error)
 	assert.Nil(t, respMissingArgs.Result)
@@ -793,7 +793,7 @@ func TestHandleToolCall(t *testing.T) {
 
 	// ** Test executeTool error **
 	// Assign specific error mock ONLY for this case
-	mcp.executeToolFunc = func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.executeToolFunc = func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		assert.Equal(t, dummyTool.Name, operationID) // Still check the name if desired
 		return nil, fmt.Errorf("mock execution error")
 	}
@@ -803,7 +803,7 @@ func TestHandleToolCall(t *testing.T) {
 		Method:  "tools/call",
 		Params:  map[string]interface{}{"name": dummyTool.Name, "arguments": map[string]interface{}{"param1": "value1"}},
 	}
-	respExecError := mcp.handleToolCall(callExecError)
+	respExecError := mcp.handleToolCall(nil, callExecError)
 	assert.NotNil(t, respExecError)
 	assert.NotNil(t, respExecError.Error)
 	assert.Nil(t, respExecError.Result)
@@ -811,6 +811,25 @@ func TestHandleToolCall(t *testing.T) {
 	assert.True(t, ok)
 	assert.EqualValues(t, -32603, errMapEE["code"]) // Use EqualValues
 	assert.Contains(t, errMapEE["message"].(string), "mock execution error")
+
+	// ** Test executeTool context **
+	testCtx := &gin.Context{Params: []gin.Param{{Key: "param1", Value: "value1"}}}
+	mcp.executeToolFunc = func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+		assert.Equal(t, testCtx, c)
+		return map[string]interface{}{"result": "success"}, nil
+	}
+
+	callExecCtx := &types.MCPMessage{
+		Jsonrpc: "2.0",
+		ID:      types.RawMessage(`"call-6"`),
+		Method:  "tools/call",
+		Params:  map[string]interface{}{"name": dummyTool.Name, "arguments": map[string]interface{}{"param1": "value1"}},
+	}
+	respCtx := mcp.handleToolCall(testCtx, callExecCtx)
+	assert.NotNil(t, respCtx)
+	assert.Nil(t, respCtx.Error, "Expected no error for valid call")
+	assert.Equal(t, callExecCtx.ID, respCtx.ID)
+	assert.NotNil(t, respCtx.Result)
 }
 
 func TestSetupServer_NotifyToolsChanged(t *testing.T) {
@@ -928,7 +947,7 @@ func TestGinMCPWithDocs(t *testing.T) {
 		Method:  "tools/list",
 	}
 
-	resp := mcp.handleToolsList(req)
+	resp := mcp.handleToolsList(nil, req)
 	assert.NotNil(t, resp)
 	assert.Nil(t, resp.Error)
 
@@ -1036,12 +1055,12 @@ func TestHandleToolCall_ForwardAuthHeaders(t *testing.T) {
 		mcp.operations[dummyTool.Name] = types.Operation{Method: "GET", Path: "/do"}
 
 		var capturedArgs map[string]interface{}
-		mcp.executeToolFunc = func(_ string, params map[string]interface{}) (interface{}, error) {
+		mcp.executeToolFunc = func(_ *gin.Context, _ string, params map[string]interface{}) (interface{}, error) {
 			capturedArgs = params
 			return "ok", nil
 		}
 
-		resp := mcp.handleToolCall(makeReq("conn-abc"))
+		resp := mcp.handleToolCall(nil, makeReq("conn-abc"))
 		assert.Nil(t, resp.Error)
 		// _mcpConnectionID must be forwarded into toolArgs so that executeToolLogic
 		// can retrieve the auth header from the transport.
@@ -1061,12 +1080,12 @@ func TestHandleToolCall_ForwardAuthHeaders(t *testing.T) {
 		mcp.operations[dummyTool.Name] = types.Operation{Method: "GET", Path: "/do"}
 
 		var capturedArgs map[string]interface{}
-		mcp.executeToolFunc = func(_ string, params map[string]interface{}) (interface{}, error) {
+		mcp.executeToolFunc = func(_ *gin.Context, _ string, params map[string]interface{}) (interface{}, error) {
 			capturedArgs = params
 			return "ok", nil
 		}
 
-		resp := mcp.handleToolCall(makeReq("conn-xyz"))
+		resp := mcp.handleToolCall(nil, makeReq("conn-xyz"))
 		assert.Nil(t, resp.Error)
 		// _mcpConnectionID must NOT reach executeToolFunc when forwarding is disabled.
 		assert.NotContains(t, capturedArgs, "_mcpConnectionID",
@@ -1132,7 +1151,7 @@ func TestHandleToolCall_CustomOperationId(t *testing.T) {
 	mcp.operations[customTool.Name] = types.Operation{Method: "GET", Path: "/custom"}
 
 	// Set up mock execution function
-	mcp.executeToolFunc = func(operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.executeToolFunc = func(_ *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		assert.Equal(t, "myCustomToolId", operationID, "Should call with custom operation ID")
 		assert.Equal(t, "test-value", parameters["input"])
 		return map[string]interface{}{"status": "executed"}, nil
@@ -1152,7 +1171,7 @@ func TestHandleToolCall_CustomOperationId(t *testing.T) {
 	}
 
 	// Execute and verify
-	resp := mcp.handleToolCall(callReq)
+	resp := mcp.handleToolCall(nil, callReq)
 	assert.NotNil(t, resp)
 	assert.Nil(t, resp.Error, "Should not have error for custom operation ID")
 	assert.Equal(t, callReq.ID, resp.ID)

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -695,7 +696,7 @@ func TestHandleToolCall(t *testing.T) {
 
 	// ** Test valid tool call **
 	// Assign mock ONLY for this case
-	mcp.executeToolFunc = func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.executeToolFunc = func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		assert.Equal(t, dummyTool.Name, operationID) // operationID is the tool name here
 		assert.Equal(t, "value1", parameters["param1"])
 		return map[string]interface{}{"result": "success"}, nil // Return nil error for success
@@ -793,7 +794,7 @@ func TestHandleToolCall(t *testing.T) {
 
 	// ** Test executeTool error **
 	// Assign specific error mock ONLY for this case
-	mcp.executeToolFunc = func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.executeToolFunc = func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		assert.Equal(t, dummyTool.Name, operationID) // Still check the name if desired
 		return nil, fmt.Errorf("mock execution error")
 	}
@@ -814,8 +815,8 @@ func TestHandleToolCall(t *testing.T) {
 
 	// ** Test executeTool context **
 	testCtx := &gin.Context{Params: []gin.Param{{Key: "param1", Value: "value1"}}}
-	mcp.executeToolFunc = func(c *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
-		assert.Equal(t, testCtx, c)
+	mcp.executeToolFunc = func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+		assert.Equal(t, testCtx, ctx)
 		return map[string]interface{}{"result": "success"}, nil
 	}
 
@@ -1055,7 +1056,7 @@ func TestHandleToolCall_ForwardAuthHeaders(t *testing.T) {
 		mcp.operations[dummyTool.Name] = types.Operation{Method: "GET", Path: "/do"}
 
 		var capturedArgs map[string]interface{}
-		mcp.executeToolFunc = func(_ *gin.Context, _ string, params map[string]interface{}) (interface{}, error) {
+		mcp.executeToolFunc = func(ctx context.Context, _ string, params map[string]interface{}) (interface{}, error) {
 			capturedArgs = params
 			return "ok", nil
 		}
@@ -1080,7 +1081,7 @@ func TestHandleToolCall_ForwardAuthHeaders(t *testing.T) {
 		mcp.operations[dummyTool.Name] = types.Operation{Method: "GET", Path: "/do"}
 
 		var capturedArgs map[string]interface{}
-		mcp.executeToolFunc = func(_ *gin.Context, _ string, params map[string]interface{}) (interface{}, error) {
+		mcp.executeToolFunc = func(ctx context.Context, _ string, params map[string]interface{}) (interface{}, error) {
 			capturedArgs = params
 			return "ok", nil
 		}
@@ -1151,7 +1152,7 @@ func TestHandleToolCall_CustomOperationId(t *testing.T) {
 	mcp.operations[customTool.Name] = types.Operation{Method: "GET", Path: "/custom"}
 
 	// Set up mock execution function
-	mcp.executeToolFunc = func(_ *gin.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
+	mcp.executeToolFunc = func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		assert.Equal(t, "myCustomToolId", operationID, "Should call with custom operation ID")
 		assert.Equal(t, "test-value", parameters["input"])
 		return map[string]interface{}{"status": "executed"}, nil

--- a/server_test.go
+++ b/server_test.go
@@ -814,7 +814,7 @@ func TestHandleToolCall(t *testing.T) {
 	assert.Contains(t, errMapEE["message"].(string), "mock execution error")
 
 	// ** Test executeTool context **
-	testCtx := &gin.Context{Params: []gin.Param{{Key: "param1", Value: "value1"}}}
+	testCtx := context.WithValue(context.Background(), "param1", "value1")
 	mcp.executeToolFunc = func(ctx context.Context, operationID string, parameters map[string]interface{}) (interface{}, error) {
 		assert.Equal(t, testCtx, ctx)
 		return map[string]interface{}{"result": "success"}, nil


### PR DESCRIPTION
Adds gin.Context to handlers.

The motivation for this that we need the func we register with `SetExecuteToolFunc` to respect cancellation and timeouts from the original request. I think it makes sense to add the context to all handlers, and it'd require giving tool handlers a special signature otherwise.

Includes a unit test.

Happy to make any changes, just let me know.

- the whitespace changes were done by `gofmt`, but I can undo them if you like