### PR TITLE
feat: add apidoc style comment parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gin-MCP: Zero-Config Gin to MCP Bridge
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/ckanthony/gin-mcp.svg)](https://pkg.go.dev/github.com/ckanthony/gin-mcp)
-[![CI](https://github.com/ckanthony/gin-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ckanthony/gin-mcp/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/dolfly/gin-mcp.svg)](https://pkg.go.dev/github.com/dolfly/gin-mcp)
+[![CI](https://github.com/dolfly/gin-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/dolfly/gin-mcp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ckanthony/gin-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/ckanthony/gin-mcp)
 ![](https://badge.mcpx.dev?type=dev 'MCP Dev')
 
@@ -50,7 +50,7 @@
 ## Installation
 
 ```bash
-go get github.com/ckanthony/gin-mcp
+go get github.com/dolfly/gin-mcp
 ```
 
 ## Basic Usage: Instant MCP Server
@@ -63,7 +63,7 @@ package main
 import (
 	"net/http"
 
-	server "github.com/ckanthony/gin-mcp/"
+	server "github.com/dolfly/gin-mcp/"
 	"github.com/gin-gonic/gin"
 )
 
@@ -166,7 +166,7 @@ package main
 
 import (
 	// ... other imports
-	"github.com/ckanthony/gin-mcp/pkg/server"
+	"github.com/dolfly/gin-mcp/pkg/server"
 	"github.com/gin-gonic/gin"
 )
 

--- a/examples/apidoc/main.go
+++ b/examples/apidoc/main.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+
+	server "github.com/ckanthony/gin-mcp"
+	"github.com/gin-gonic/gin"
+)
+
+// Product represents a product in our store
+type Product struct {
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Price       float64  `json:"price"`
+	Tags        []string `json:"tags,omitempty"`
+	IsEnabled   bool     `json:"is_enabled"`
+}
+
+// In-memory store
+var (
+	products = make(map[int]*Product)
+	nextID   = 1
+)
+
+func main() {
+	gin.SetMode(gin.DebugMode)
+	r := gin.Default()
+
+	// Register API routes with apidoc style comments
+	registerRoutes(r)
+
+	// Initialize and configure MCP server
+	configureMCP(r)
+
+	// Start the server
+	r.Run(":8080")
+}
+
+func registerRoutes(r *gin.Engine) {
+	r.GET("/products", listProducts)
+	r.GET("/products/:id", getProduct)
+	r.POST("/products", createProduct)
+	r.DELETE("/products/:id", deleteProduct)
+}
+
+func configureMCP(r *gin.Engine) {
+	mcp := server.New(r, &server.Config{
+		Name:        "Product API (apidoc style)",
+		Description: "RESTful API for managing products with apidoc annotations",
+		BaseURL:     "http://localhost:8080",
+	})
+
+	// Mount MCP endpoint
+	mcp.Mount("/mcp")
+}
+
+// @api {get} /products List all products
+// @apiName ListProducts
+// @apiGroup Product
+// @apiDescription Retrieve a paginated list of products with optional filtering
+// @apiParam {Number} [page=1] Page number for pagination
+// @apiParam {Number} [limit=10] Number of items per page
+// @apiSuccess {Object[]} products List of products
+// @apiSuccess {Number} products.id Product ID
+// @apiSuccess {String} products.name Product name
+func listProducts(c *gin.Context) {
+	page := 1
+	limit := 10
+
+	if p := c.Query("page"); p != "" {
+		if val, err := strconv.Atoi(p); err == nil && val > 0 {
+			page = val
+		}
+	}
+	if l := c.Query("limit"); l != "" {
+		if val, err := strconv.Atoi(l); err == nil && val > 0 && val <= 100 {
+			limit = val
+		}
+	}
+
+	var result []*Product
+	for _, product := range products {
+		result = append(result, product)
+	}
+
+	start := (page - 1) * limit
+	if start >= len(result) {
+		c.JSON(http.StatusOK, gin.H{"products": []*Product{}, "total": len(result)})
+		return
+	}
+
+	end := start + limit
+	if end > len(result) {
+		end = len(result)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"products": result[start:end],
+		"total":    len(result),
+	})
+}
+
+// @api {get} /products/:id Get product details
+// @apiName GetProduct
+// @apiGroup Product
+// @apiDescription Get detailed information about a specific product
+// @apiParam {Number} id Product unique ID
+// @apiSuccess {Number} id Product ID
+// @apiSuccess {String} name Product name
+// @apiSuccess {String} description Product description
+// @apiSuccess {Number} price Product price
+// @apiError ProductNotFound Product was not found
+func getProduct(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	if product, exists := products[id]; exists {
+		c.JSON(http.StatusOK, product)
+		return
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "Product not found"})
+}
+
+// @api {post} /products Create new product
+// @apiName CreateProduct
+// @apiGroup Product
+// @apiDescription Create a new product in the catalog
+// @apiParam {String} name Product name (required)
+// @apiParam {String} [description] Product description
+// @apiParam {Number} price Product price in USD (required)
+// @apiParam {String[]} [tags] Product categories
+// @apiParam {Boolean} is_enabled Whether product is available (required)
+// @apiSuccess {Number} id Created product ID
+// @apiSuccess {String} name Product name
+func createProduct(c *gin.Context) {
+	var product Product
+	if err := c.ShouldBindJSON(&product); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	product.ID = nextID
+	nextID++
+	products[product.ID] = &product
+	c.JSON(http.StatusCreated, product)
+}
+
+// @api {delete} /products/:id Delete product
+// @apiName DeleteProduct
+// @apiGroup Product
+// @apiDescription Permanently remove a product from the catalog
+// @apiParam {Number} id Product unique ID
+// @apiSuccess (204) {Void} null No content
+// @apiError ProductNotFound Product was not found
+func deleteProduct(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	if _, exists := products[id]; exists {
+		delete(products, id)
+		c.Status(http.StatusNoContent)
+		return
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "Product not found"})
+}

--- a/examples/apidoc/main.go
+++ b/examples/apidoc/main.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	server "github.com/ckanthony/gin-mcp"
+	server "github.com/dolfly/gin-mcp"
 	"github.com/gin-gonic/gin"
 )
 

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	server "github.com/ckanthony/gin-mcp"
+	server "github.com/dolfly/gin-mcp"
 	"github.com/gin-gonic/gin"
 )
 

--- a/examples/simple/quicknode.go
+++ b/examples/simple/quicknode.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	server "github.com/ckanthony/gin-mcp"
+	server "github.com/dolfly/gin-mcp"
 	"github.com/gin-gonic/gin"
 )
 

--- a/examples/simple/ragflow.go
+++ b/examples/simple/ragflow.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strings"
 
-	server "github.com/ckanthony/gin-mcp"
+	server "github.com/dolfly/gin-mcp"
 	"github.com/gin-gonic/gin"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ckanthony/gin-mcp
+module github.com/dolfly/gin-mcp
 
 go 1.21
 
@@ -40,4 +40,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace github.com/ckanthony/gin-mcp => ./
+// replace github.com/dolfly/gin-mcp => ./

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -351,7 +351,14 @@ func parseApidocComments(commentText string, doc *HandlerDoc) {
 		case strings.HasPrefix(line, "@apiGroup "):
 			group := strings.TrimSpace(strings.TrimPrefix(line, "@apiGroup"))
 			if group != "" {
-				doc.Tags = []string{group}
+				// Split by spaces to support multiple tags
+				var tags []string
+				for _, part := range strings.Fields(group) {
+					if part != "" {
+						tags = append(tags, part)
+					}
+				}
+				doc.Tags = tags
 			}
 		case strings.HasPrefix(line, "@apiParam "):
 			// @apiParam [(group)] [{type}] [field=defaultValue] [description]

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -11,7 +11,7 @@ import (
 	"go/parser"
 	"go/token"
 
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -283,6 +283,7 @@ type HandlerDoc struct {
 }
 
 // parseHandlerComments parses function documentation from source code
+// Supports both custom annotations (@summary, @description, etc.) and apidoc format (@api, @apiParam, etc.)
 func parseHandlerComments(filePath string, handlerName string) (*HandlerDoc, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
@@ -301,50 +302,12 @@ func parseHandlerComments(filePath string, handlerName string) (*HandlerDoc, err
 					Params: make(map[string]string),
 				}
 				if fn.Doc != nil {
-					// Parse comments
-					lines := strings.Split(fn.Doc.Text(), "\n")
-					for _, line := range lines {
-						line = strings.TrimSpace(line)
-						switch {
-						case strings.HasPrefix(line, "@summary"):
-							doc.Summary = strings.TrimSpace(strings.TrimPrefix(line, "@summary"))
-						case strings.HasPrefix(line, "@description"):
-							doc.Description = strings.TrimSpace(strings.TrimPrefix(line, "@description"))
-						case strings.HasPrefix(line, "@param"):
-							paramText := strings.TrimSpace(strings.TrimPrefix(line, "@param"))
-							parts := strings.SplitN(paramText, " ", 2)
-							if len(parts) == 2 {
-								paramName := strings.TrimSpace(parts[0])
-								paramDesc := strings.TrimSpace(parts[1])
-								doc.Params[paramName] = paramDesc
-							}
-						case strings.HasPrefix(line, "@return"):
-							doc.Returns = strings.TrimSpace(strings.TrimPrefix(line, "@return"))
-						case strings.HasPrefix(line, "@tags"):
-							tagsText := strings.TrimSpace(strings.TrimPrefix(line, "@tags"))
-							// Split on spaces and commas, trim whitespace, ignore empty entries
-							var tags []string
-							for _, sep := range []string{",", " "} {
-								parts := strings.Split(tagsText, sep)
-								for _, part := range parts {
-									trimmed := strings.TrimSpace(part)
-									if trimmed != "" && !contains(tags, trimmed) {
-										tags = append(tags, trimmed)
-									}
-								}
-								// After first pass with commas, rejoin and split by spaces
-								if sep == "," {
-									tagsText = strings.Join(tags, " ")
-									tags = []string{}
-								}
-							}
-							doc.Tags = tags
-						case strings.HasPrefix(line, "@operationId"):
-							opID := strings.TrimSpace(strings.TrimPrefix(line, "@operationId"))
-							if opID != "" && doc.OperationID == "" {
-								doc.OperationID = opID
-							}
-						}
+					// Check if this is apidoc format
+					if isApidocFormat(fn.Doc.Text()) {
+						parseApidocComments(fn.Doc.Text(), doc)
+					} else {
+						// Parse custom annotations
+						parseCustomComments(fn.Doc.Text(), doc)
 					}
 				}
 			}
@@ -352,6 +315,208 @@ func parseHandlerComments(filePath string, handlerName string) (*HandlerDoc, err
 	}
 
 	return doc, nil
+}
+
+// isApidocFormat checks if the comment block uses apidoc format (has @api annotation)
+func isApidocFormat(commentText string) bool {
+	lines := strings.Split(commentText, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "@api ") || strings.HasPrefix(line, "@api\t") {
+			return true
+		}
+	}
+	return false
+}
+
+// parseApidocComments parses apidoc style annotations
+func parseApidocComments(commentText string, doc *HandlerDoc) {
+	lines := strings.Split(commentText, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "@api "):
+			// @api {method} path title
+			parseApiAnnotation(line, doc)
+		case strings.HasPrefix(line, "@apiDescription "):
+			doc.Description = strings.TrimSpace(strings.TrimPrefix(line, "@apiDescription"))
+		case strings.HasPrefix(line, "@apiName "):
+			doc.OperationID = strings.TrimSpace(strings.TrimPrefix(line, "@apiName"))
+		case strings.HasPrefix(line, "@apiGroup "):
+			group := strings.TrimSpace(strings.TrimPrefix(line, "@apiGroup"))
+			if group != "" {
+				doc.Tags = []string{group}
+			}
+		case strings.HasPrefix(line, "@apiParam "):
+			// @apiParam [(group)] [{type}] [field=defaultValue] [description]
+			parseApiParamAnnotation(line, doc)
+		}
+	}
+}
+
+// parseApiAnnotation parses @api {method} path title
+func parseApiAnnotation(line string, doc *HandlerDoc) {
+	// Remove @api prefix
+	content := strings.TrimSpace(strings.TrimPrefix(line, "@api"))
+	// Find {method}
+	start := strings.Index(content, "{")
+	end := strings.Index(content, "}")
+	if start == -1 || end == -1 || end <= start {
+		return
+	}
+	// Extract title (everything after path)
+	remaining := strings.TrimSpace(content[end+1:])
+	// Skip path, extract title
+	parts := strings.Fields(remaining)
+	if len(parts) > 1 {
+		// First part is path, rest is title
+		title := strings.Join(parts[1:], " ")
+		if title != "" {
+			doc.Summary = title
+		}
+	} else if len(parts) == 1 {
+		// Only path, no title - use default summary
+		doc.Summary = "API endpoint"
+	}
+}
+
+// parseApiParamAnnotation parses @apiParam [(group)] [{type}] [field=defaultValue] [description]
+func parseApiParamAnnotation(line string, doc *HandlerDoc) {
+	// Remove @apiParam prefix
+	content := strings.TrimSpace(strings.TrimPrefix(line, "@apiParam"))
+
+	// Skip optional group in parentheses
+	if strings.HasPrefix(content, "(") {
+		endParen := strings.Index(content, ")")
+		if endParen != -1 {
+			content = strings.TrimSpace(content[endParen+1:])
+		}
+	}
+
+	// Skip type in braces
+	if strings.HasPrefix(content, "{") {
+		endBrace := strings.Index(content, "}")
+		if endBrace != -1 {
+			content = strings.TrimSpace(content[endBrace+1:])
+		}
+	}
+
+	// Parse field and description
+	// Field can be: field, [field], field=default, [field=default]
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return
+	}
+
+	// Extract field name (handle optional and default value)
+	var fieldName string
+	rest := content
+
+	// Check if optional (starts with [)
+	if strings.HasPrefix(rest, "[") {
+		// Find matching closing bracket, handling nested brackets
+		depth := 1
+		endBracket := -1
+		for i := 1; i < len(rest); i++ {
+			if rest[i] == '[' {
+				depth++
+			} else if rest[i] == ']' {
+				depth--
+				if depth == 0 {
+					endBracket = i
+					break
+				}
+			}
+		}
+		if endBracket != -1 {
+			fieldPart := rest[1:endBracket]
+			// Remove default value if present
+			if eqIdx := strings.Index(fieldPart, "="); eqIdx != -1 {
+				fieldName = fieldPart[:eqIdx]
+			} else {
+				fieldName = fieldPart
+			}
+			rest = strings.TrimSpace(rest[endBracket+1:])
+		}
+	} else {
+		// Not optional
+		parts := strings.Fields(rest)
+		if len(parts) > 0 {
+			fieldPart := parts[0]
+			// Remove default value if present
+			if eqIdx := strings.Index(fieldPart, "="); eqIdx != -1 {
+				fieldName = fieldPart[:eqIdx]
+			} else {
+				fieldName = fieldPart
+			}
+			rest = strings.TrimSpace(strings.TrimPrefix(rest, fieldPart))
+		}
+	}
+
+	// Handle nested field names like parent[child] -> extract "child"
+	// This handles the case where fieldPart contains nested brackets (e.g., "address[city]")
+	if strings.Contains(fieldName, "[") && strings.HasSuffix(fieldName, "]") {
+		startBracket := strings.Index(fieldName, "[")
+		endBracket := strings.LastIndex(fieldName, "]")
+		if startBracket != -1 && endBracket != -1 && endBracket > startBracket {
+			fieldName = fieldName[startBracket+1 : endBracket]
+		}
+	}
+
+	fieldName = strings.TrimSpace(fieldName)
+	rest = strings.TrimSpace(rest)
+
+	if fieldName != "" && rest != "" {
+		doc.Params[fieldName] = rest
+	}
+}
+
+// parseCustomComments parses custom annotations (@summary, @description, @param, @return, @tags, @operationId)
+func parseCustomComments(commentText string, doc *HandlerDoc) {
+	lines := strings.Split(commentText, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "@summary"):
+			doc.Summary = strings.TrimSpace(strings.TrimPrefix(line, "@summary"))
+		case strings.HasPrefix(line, "@description"):
+			doc.Description = strings.TrimSpace(strings.TrimPrefix(line, "@description"))
+		case strings.HasPrefix(line, "@param"):
+			paramText := strings.TrimSpace(strings.TrimPrefix(line, "@param"))
+			parts := strings.SplitN(paramText, " ", 2)
+			if len(parts) == 2 {
+				paramName := strings.TrimSpace(parts[0])
+				paramDesc := strings.TrimSpace(parts[1])
+				doc.Params[paramName] = paramDesc
+			}
+		case strings.HasPrefix(line, "@return"):
+			doc.Returns = strings.TrimSpace(strings.TrimPrefix(line, "@return"))
+		case strings.HasPrefix(line, "@tags"):
+			tagsText := strings.TrimSpace(strings.TrimPrefix(line, "@tags"))
+			// Split on spaces and commas, trim whitespace, ignore empty entries
+			var tags []string
+			for _, sep := range []string{",", " "} {
+				parts := strings.Split(tagsText, sep)
+				for _, part := range parts {
+					trimmed := strings.TrimSpace(part)
+					if trimmed != "" && !contains(tags, trimmed) {
+						tags = append(tags, trimmed)
+					}
+				}
+				// After first pass with commas, rejoin and split by spaces
+				if sep == "," {
+					tagsText = strings.Join(tags, " ")
+					tags = []string{}
+				}
+			}
+			doc.Tags = tags
+		case strings.HasPrefix(line, "@operationId"):
+			opID := strings.TrimSpace(strings.TrimPrefix(line, "@operationId"))
+			if opID != "" && doc.OperationID == "" {
+				doc.OperationID = opID
+			}
+		}
+	}
 }
 
 func getHandlerInfo(handler gin.HandlerFunc) (string, string) {

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -322,6 +322,9 @@ func isApidocFormat(commentText string) bool {
 	lines := strings.Split(commentText, "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
+		// Strip leading * from block comments
+		line = strings.TrimPrefix(line, "*")
+		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "@api ") || strings.HasPrefix(line, "@api\t") {
 			return true
 		}
@@ -333,6 +336,9 @@ func isApidocFormat(commentText string) bool {
 func parseApidocComments(commentText string, doc *HandlerDoc) {
 	lines := strings.Split(commentText, "\n")
 	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		// Strip leading * from block comments (/** ... */)
+		line = strings.TrimPrefix(line, "*")
 		line = strings.TrimSpace(line)
 		switch {
 		case strings.HasPrefix(line, "@api "):

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -848,7 +848,7 @@ func GetProduct(c *gin.Context) {}
 	assert.NoError(t, err)
 	assert.NotNil(t, doc)
 	assert.Equal(t, "总体报表-渠道反作弊-渠道方风险-列表", strings.TrimSpace(doc.Summary))
-	assert.Equal(t, []string{"ACG APIS"}, doc.Tags)
+	assert.Equal(t, []string{"ACG", "APIS"}, doc.Tags)
 	assert.Equal(t, "活动开始时间，格式：YYYYMMDD, 如20180511", strings.TrimSpace(doc.Params["stime"]))
 	assert.Equal(t, "活动截止时间，格式：YYYYMMDD, 如20180511", strings.TrimSpace(doc.Params["etime"]))
 	assert.Equal(t, "\"pv\", \"uv\" 默认pv", strings.TrimSpace(doc.Params["type"]))

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -741,6 +741,150 @@ func HandlerNoOperationId(c *gin.Context) {}
 	assert.Empty(t, doc.OperationID)
 }
 
+// TestParseApidocComments tests apidoc format parsing
+func TestParseApidocComments(t *testing.T) {
+	tmpFile := `package test
+
+import "github.com/gin-gonic/gin"
+
+// @api {get} /user/:id Get user information
+// @apiName GetUser
+// @apiGroup User
+// @apiDescription Get detailed user information by ID
+// @apiParam {Number} id Users unique ID
+// @apiParam {String} [firstname] Optional firstname
+// @apiParam {String} country="DE" Mandatory with default
+func GetUser(c *gin.Context) {}
+
+// @api {post} /user Create new user
+// @apiName CreateUser
+// @apiGroup User
+// @apiParam {String} name Username
+// @apiParam {String} email User email address
+// @apiParam (login) {String} pass User password
+func CreateUser(c *gin.Context) {}
+
+// @api {get} /products List products
+// @apiGroup Product
+// @apiDescription Retrieve a list of all products
+func ListProducts(c *gin.Context) {}
+`
+	// Create temporary file
+	tmpDir := t.TempDir()
+	tmpPath := filepath.Join(tmpDir, "apidoc_test.go")
+	err := os.WriteFile(tmpPath, []byte(tmpFile), 0644)
+	assert.NoError(t, err)
+
+	// Test GetUser with full apidoc annotations
+	doc, err := parseHandlerComments(tmpPath, "GetUser")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "Get user information", strings.TrimSpace(doc.Summary))
+	assert.Equal(t, "Get detailed user information by ID", strings.TrimSpace(doc.Description))
+	assert.Equal(t, "GetUser", doc.OperationID)
+	assert.Equal(t, []string{"User"}, doc.Tags)
+	assert.Equal(t, "Users unique ID", strings.TrimSpace(doc.Params["id"]))
+	assert.Equal(t, "Optional firstname", strings.TrimSpace(doc.Params["firstname"]))
+	assert.Equal(t, "Mandatory with default", strings.TrimSpace(doc.Params["country"]))
+
+	// Test CreateUser with group parameter
+	doc, err = parseHandlerComments(tmpPath, "CreateUser")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "Create new user", strings.TrimSpace(doc.Summary))
+	assert.Equal(t, "CreateUser", doc.OperationID)
+	assert.Equal(t, "Username", strings.TrimSpace(doc.Params["name"]))
+	assert.Equal(t, "User email address", strings.TrimSpace(doc.Params["email"]))
+	assert.Equal(t, "User password", strings.TrimSpace(doc.Params["pass"]))
+
+	// Test ListProducts without @apiName
+	doc, err = parseHandlerComments(tmpPath, "ListProducts")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "List products", strings.TrimSpace(doc.Summary))
+	assert.Equal(t, "Retrieve a list of all products", strings.TrimSpace(doc.Description))
+	assert.Empty(t, doc.OperationID) // No @apiName
+	assert.Equal(t, []string{"Product"}, doc.Tags)
+}
+
+// TestParseApidocComments_EdgeCases tests apidoc edge cases
+func TestParseApidocComments_EdgeCases(t *testing.T) {
+	tmpFile := `package test
+
+import "github.com/gin-gonic/gin"
+
+// @api {get} /minimal
+// @apiGroup Minimal
+func MinimalEndpoint(c *gin.Context) {}
+
+// @api {put} /update/:id Update resource
+// @apiName UpdateResource
+// @apiParam {String} [address[city]] Optional nested city
+// @apiParam {Number} age Users age
+func UpdateResource(c *gin.Context) {}
+`
+	tmpDir := t.TempDir()
+	tmpPath := filepath.Join(tmpDir, "apidoc_edge_test.go")
+	err := os.WriteFile(tmpPath, []byte(tmpFile), 0644)
+	assert.NoError(t, err)
+
+	// Test minimal endpoint (no title)
+	doc, err := parseHandlerComments(tmpPath, "MinimalEndpoint")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "API endpoint", doc.Summary) // Default when no title
+
+	// Test nested field name
+	doc, err = parseHandlerComments(tmpPath, "UpdateResource")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "Update resource", doc.Summary)
+	// Nested field should extract "city" from "address[city]"
+	assert.Equal(t, "Optional nested city", strings.TrimSpace(doc.Params["city"]))
+	assert.Equal(t, "Users age", strings.TrimSpace(doc.Params["age"]))
+}
+
+// TestIsApidocFormat tests detection of apidoc format
+func TestIsApidocFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		comment  string
+		expected bool
+	}{
+		{
+			name: "apidoc format",
+			comment: `@api {get} /user Get user
+@apiName GetUser
+@apiGroup User`,
+			expected: true,
+		},
+		{
+			name: "custom format with @api (tab)",
+			comment: `@api	{get} /user Get user`,
+			expected: true,
+		},
+		{
+			name: "custom format",
+			comment: `@summary Get user
+@description Get user details
+@param id User ID`,
+			expected: false,
+		},
+		{
+			name:     "empty comment",
+			comment:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isApidocFormat(tt.comment)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestParseHandlerComments_Tags(t *testing.T) {
 	tmpFile := `package test
 

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -807,6 +807,65 @@ func ListProducts(c *gin.Context) {}
 	assert.Equal(t, []string{"Product"}, doc.Tags)
 }
 
+// TestParseApidocBlockComments tests apidoc block comment format (/** ... */)
+func TestParseApidocBlockComments(t *testing.T) {
+	// This simulates how Go's AST parses block comments
+	// The fn.Doc.Text() returns lines with * prefix for block comments
+	tmpFile := `package test
+
+import "github.com/gin-gonic/gin"
+
+// OverallChannelList def
+/**
+* @api {post} /act/v1/overall/acg/channel 总体报表-渠道反作弊-渠道方风险-列表
+*
+* @apiGroup ACG APIS
+* @apiParam {String} stime 活动开始时间，格式：YYYYMMDD, 如20180511
+* @apiParam {String} etime 活动截止时间，格式：YYYYMMDD, 如20180511
+* @apiParam {String} [type] "pv", "uv" 默认pv
+* @apiParam {Number} [pn=1] 查询页码
+* @apiParam {Number} [pl=10] 每页数量
+* @apiVersion 2.2.0
+*/
+func OverallChannelList(c *gin.Context) {}
+
+/**
+* @api {get} /products/:id Get product details
+* @apiName GetProduct
+* @apiGroup Product
+* @apiDescription Get detailed information about a specific product
+* @apiParam {Number} id Product unique ID
+*/
+func GetProduct(c *gin.Context) {}
+`
+	tmpDir := t.TempDir()
+	tmpPath := filepath.Join(tmpDir, "apidoc_block_test.go")
+	err := os.WriteFile(tmpPath, []byte(tmpFile), 0644)
+	assert.NoError(t, err)
+
+	// Test OverallChannelList with block comment format
+	doc, err := parseHandlerComments(tmpPath, "OverallChannelList")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "总体报表-渠道反作弊-渠道方风险-列表", strings.TrimSpace(doc.Summary))
+	assert.Equal(t, []string{"ACG APIS"}, doc.Tags)
+	assert.Equal(t, "活动开始时间，格式：YYYYMMDD, 如20180511", strings.TrimSpace(doc.Params["stime"]))
+	assert.Equal(t, "活动截止时间，格式：YYYYMMDD, 如20180511", strings.TrimSpace(doc.Params["etime"]))
+	assert.Equal(t, "\"pv\", \"uv\" 默认pv", strings.TrimSpace(doc.Params["type"]))
+	assert.Equal(t, "查询页码", strings.TrimSpace(doc.Params["pn"]))
+	assert.Equal(t, "每页数量", strings.TrimSpace(doc.Params["pl"]))
+
+	// Test GetProduct with block comment format
+	doc, err = parseHandlerComments(tmpPath, "GetProduct")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "Get product details", strings.TrimSpace(doc.Summary))
+	assert.Equal(t, "Get detailed information about a specific product", strings.TrimSpace(doc.Description))
+	assert.Equal(t, "GetProduct", doc.OperationID)
+	assert.Equal(t, []string{"Product"}, doc.Tags)
+	assert.Equal(t, "Product unique ID", strings.TrimSpace(doc.Params["id"]))
+}
+
 // TestParseApidocComments_EdgeCases tests apidoc edge cases
 func TestParseApidocComments_EdgeCases(t *testing.T) {
 	tmpFile := `package test

--- a/pkg/transport/sse.go
+++ b/pkg/transport/sse.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"

--- a/pkg/transport/sse_test.go
+++ b/pkg/transport/sse_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/pkg/transport/streamable_http.go
+++ b/pkg/transport/streamable_http.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"

--- a/pkg/transport/streamable_http_test.go
+++ b/pkg/transport/streamable_http_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -1,7 +1,7 @@
 package transport
 
 import (
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 )
 

--- a/server.go
+++ b/server.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/ckanthony/gin-mcp/pkg/convert"
-	"github.com/ckanthony/gin-mcp/pkg/transport"
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	"github.com/dolfly/gin-mcp/pkg/convert"
+	"github.com/dolfly/gin-mcp/pkg/transport"
+	"github.com/dolfly/gin-mcp/pkg/types"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/server_test.go
+++ b/server_test.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"testing"
 
-	transport "github.com/ckanthony/gin-mcp/pkg/transport"
-	"github.com/ckanthony/gin-mcp/pkg/types"
+	transport "github.com/dolfly/gin-mcp/pkg/transport"
+	"github.com/dolfly/gin-mcp/pkg/types"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
- Add isApidocFormat() to detect apidoc format comments
- Add parseApidocComments() to parse apidoc annotations
- Add parseApiAnnotation() to parse @api {method} path title
- Add parseApiParamAnnotation() to parse @apiParam with nested fields
- Add parseCustomComments() for original format parsing
- Modify parseHandlerComments() to auto-detect and use appropriate parser
- Add comprehensive tests for apidoc parsing
- Add example in examples/apidoc/main.go

Supported apidoc annotations:
- @api {method} path title
- @apiName name (maps to operationId)
- @apiGroup name (maps to tags)
- @apiDescription text
- @apiParam [(group)] [{type}] [field=defaultValue] [description]